### PR TITLE
Update beacons.md

### DIFF
--- a/hardware/beacons.md
+++ b/hardware/beacons.md
@@ -31,6 +31,7 @@ nav_order: 2
 | FitBits             | Only works well when not connected to app
 | Xiaomi Watch        | Only works well when not connected to app
 | Apple AirTags       | Doesn't work, privacy is similar to exp tokens
+| HUAWEI Band 6       | Only works when not connected to a phone
 
 ### Add to the list
 


### PR DESCRIPTION
HUAWEI Band 6 only advertises itself and works when not connected to a phone.

It initially didn't show the mac address in the logs or any Bluetooth scanning applications, once I switched off Bluetooth on the phone it's connected to, I was able to see the MAC in the logs and the tracking entity in Home Assistant was updated