### PR TITLE
Added the Amazfit GTS 2 Mini

### DIFF
--- a/hardware/beacons.md
+++ b/hardware/beacons.md
@@ -17,6 +17,7 @@ nav_order: 2
 | Blue Charm Beacons   | Yes       | [amazon](https://amzn.to/2YGdA3w)           | Configure as iBeacon or eddystone, don't enable both at the same time
 | MiBand               | 2,5,6 *   | [amazon](https://amzn.to/3E8AJMh)           | Make sure discoverable is turned on
 | Amazfit Bip S        | Yes       | [amazon](https://amzn.to/3C4DyMK)           |
+| Amazfit GTS 2 Mini   | Yes       | [amazon](https://www.amazon.com/dp/B08PCYKXV5?psc=1&ref=ppx_yo2ov_dt_b_product_details)  |
 | Puck-JS              | Yes       | [espruino](https://www.espruino.com/Puck.js)| If programmed to [broadcast beacon packets](https://gist.github.com/jptrsn/d6cb9b9cdbcd41f3500708f8b694cad2)
 | Generic BTLE Beacons | Yes       |                                             | Anything that follows the iBeacon or Eddystone standards
 | MiFlora plant sensor | Yes *     |                                             | Location only


### PR DESCRIPTION
I just purchased the Amazfit GTS 2 Mini and I have it up an working with ESPresense.  I added it to the documentation.  You may want to shorten my link using your affiliate link.