### PR TITLE
Indicate that sensors like 🌡️🔆⚖️ can be used

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,6 +15,15 @@ An ESP32 based presence detection node for use with the [Home Assistant](https:/
 * [Tracking beacons](./beacons)
 * [MQTT Server](https://mosquitto.org/)
 
+## Optional Sensors
+
+* PIR Motion
+* Radar Motion
+* Temperature (DHT11, DHT22)
+* Ambient Light (BH1750, TSL2561)
+* Weather Sensor (BME280)
+* Weight Sensor (HX711)
+
 ## Installation
 
 Check out the [installation page](install)


### PR DESCRIPTION
#15 
It's not very clear in the documentation that all these sensors are also supported and automatically discovered by home assistant with MQTT. Therefore, you find a lot of people who want this to be part of Esphome. I'll proceed to enrich the installation page to inform the user which firmware enables the use of those sensors.
@DTTerastar thanks for the great work adding those sensors