### PR TITLE
Update documentation to allow for parsing of either base64 string or XML IRK

### DIFF
--- a/apple.md
+++ b/apple.md
@@ -43,49 +43,75 @@ An Apple Watch cannot be paired with Bluetooth to the ESPresense instance. You h
 
 1. **Open** each **GUID** to find the one associated with your apple watch. You should see your watches GUID as part of the **Account** field in the format: `Public: XX:XX:XX:XX:XX:XX`
 3. **Click** on **Show password**
-4. **Type** your MacOS password **twice** and **copy** the **XML contents** to a text editor.
+4. **Type** your MacOS password **twice** and **copy** the contents.
 
     ![keychain-password](../images/keychain_password.png)
 
-3. **Find** the `Remote IRK` key and **copy** the *base64 encoded* string in the *data* key:
+5. Paste the contents in the form below and click 'Decode' to convert this into an IRK. Under the hood, this is extracting Base64 data and converting it to a hex string and then reversing the order of the bytes.
 
-    ```xml
-    <key>Remote IRK</key>
-    <data>aGktZnJvbS1qb2Vw</data>
-    ```
+    <center>
+    <div>
+      <script>
+      // Regex to validate base64 strings
+      var b64_regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
-9. Paste the IRK in the form below and click 'Decode' to convert this into an IRK. Under the hood, this is convert the Base64 data to a hex string and then reversing the order of the bytes.
+      // Attempt to decode this as if it was an XML document straight from keychain.
+      // Return null if this cannot be done.
+      function tryDecodeXML(str) {
+        var parser = new DOMParser();
+        var doc = parser.parseFromString(str,"text/xml");
+        var dataElement = doc.getElementsByTagName('data');
+        if (!dataElement || dataElement.length < 1) {
+            return null;
+        }
+        var b64 = dataElement[0].innerHTML.trim();
+        return tryDecodeBase64(b64);
+      }
 
-<center>
-<div>
-  <script>
-  function base64ToHex(str) {
-    for (var i = 0, bin = atob(str.replace(/[ \r\n]+$/, "")), hex = []; i < bin.length; ++i) {
-        let tmp = bin.charCodeAt(i).toString(16);
-        if (tmp.length === 1) tmp = "0" + tmp;
-        hex[hex.length] = tmp;
-    }
-    return hex;
-  }
+      function isBase64(str) {
+        return !!b64_regex.exec(str);
+      }
 
-  function decode(e) {
-    const input = document.getElementById('base64_input');
-    const output = document.getElementById('base64_output');
-    const data = input.value;
-    output.innerText = base64ToHex(data).reverse().join('');
-  }
-  </script>
-  <input type="text" id="base64_input" size="32">
-  <button type="button" onclick="decode()">Convert</button>
-  <br><br>
-  <b>Output</b>
-  <div id="base64_output" style="font-family: monospace;"><span style="color: gray">Enter base64 above...</span></div>
-</div>
-</center>
+      function tryDecodeBase64(str) {
+        if (!isBase64(str)) {
+            return null;
+        }
 
-11. Add the output (which should be 32 characters) to the 'Known BLE identity resolving keys' section of the ESPresence configuration.
+        for (var i = 0, bin = atob(str.replace(/[ \r\n]+$/, "")), hex = []; i < bin.length; ++i) {
+            var tmp = bin.charCodeAt(i).toString(16);
+            if (tmp.length === 1) tmp = "0" + tmp;
+            hex[hex.length] = tmp;
+        }
+        return hex;
+      }
+
+      function decode(e) {
+        var input = document.getElementById('base64_input');
+        var output = document.getElementById('base64_output');
+        var data = input.value;
+
+        var decoded = tryDecodeXML(data) || tryDecodeBase64(data);
+        if (!decoded) {
+            output.innerText = "Please paste the XML from iCloud or a Base64 encoded string";
+            output.style = 'color: red;';
+            return;
+        }
+        
+        output.innerText = decoded.reverse().join('');
+      }
+      </script>
+      <textarea type="text" id="base64_input" cols="32" rows="12"></textarea><br><br>
+      <button type="button" onclick="decode()">Convert</button>
+      <br><br>
+      <b>Output</b>
+      <div id="base64_output" style="font-family: monospace;"><span style="color: gray">Enter base64 above...</span></div>
+      <br><br>
+    </div>
+    </center>
+
+6. Add the output (which should be 32 characters) to the 'Known BLE identity resolving keys' section of the ESPresence configuration.
     
-![ble-irk](../images/known_ble_irk.png)
+    ![ble-irk](../images/known_ble_irk.png)
     
-12. Add the same string to your HASS configuration with 'irk:' added in front e.g. "irk:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+7. Add the same string to your HASS configuration with 'irk:' added in front e.g. "irk:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 


### PR DESCRIPTION
This change updates the documentation to also support decoding the full XML document containing the Apple Watch IRK if copy/pasted from iCloud.