### PR TITLE
Update apple.md

### DIFF
--- a/apple.md
+++ b/apple.md
@@ -9,6 +9,8 @@ parent: Beacons
 
 Apple devices emit various [BTLE continuity](https://github.com/furiousMAC/continuity) messages, often identified by the fingerprint `apple:100?:*-*`. In households with multiple iPhones, the nearby info may collide, leading to duplicate fingerprints. To resolve this, you can obtain the remote IRK (Identity Resolving Key) from your iOS (iPhone, iPad) or Watch OS (Apple Watch) device. While adding the IRK to the `Known BLE identity resolving keys` section of the ESPresense configuration is an option, using the `Enroll` feature is recommended as it's easier and syncs automatically to all ESPresense nodes. Note: ESPresense version 3.0 or higher is required!**
 
+Note: Some iOS devices do not emit a beacon while the phone screen is off if there is not a reason for the device to broadcast a signal, consequently the device may not appear while the screen is off. Something like an iWatch, Universal Clipboard with Handoff enabled, or other services that require the phone to communicate regularly may resolve this issue as they require the subject iOS device to communicate while 'sleeping'. In the case you do not have a bluetooth device like an iWatch, some people report that using background apps like iCloud Family Sharing, iCloud Photo Backup, or Room Assistant have convinced the device to communicate while 'sleeping'. This issue is not universal, but it's not clear why this occurs at this time and you may not experience this issue even if the device seemingly has no reason to communicate.
+
 ## Enrollment (easiest)
 
 ## iPhone / iPads (native)


### PR DESCRIPTION
Updated to add a note regarding iOS devices stopping communications while the screen is off, while not universal this issue is very frustrating to solve if it is occurring and difficult to find notes on it. Users must work on the iOS device itself to try and get it to broadcast rather then focusing on ESPresense.  Related Issue ESPresense [#691](https://github.com/ESPresense/ESPresense/issues/691)