### PR TITLE
Added a second option for manual IRK decoding

### DIFF
--- a/apple.md
+++ b/apple.md
@@ -54,9 +54,18 @@ This method can be used for any iOS/iPadOS/Watch OS device:
 
 {% include irk_decode.html %}
 
+### Option 1
+
 - Add the output (which should be 32 characters) to the 'Known BLE identity resolving keys' section of the ESPresence configuration.
 
     ![ble-irk](../images/known_ble_irk.png)
 
 - In your HASS configuration, add the same string with 'irk:' prefixed, e.g., "irk:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx".
 - Click 'Save' in the ESPresense UI, then 'Restart Device'.
+
+### Option 2
+
+- Alternatively you can publish an MQTT message to the settings topic to simulate what would happen were you to pair from the UI. To do this you can publish to the topic: `espresense/settings/irk:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` with a payload `{"id":"device_id", "name":"Device Name"}`. _Make sure there are no spaces in the `id` value._
+
+
+


### PR DESCRIPTION
I didn't like the existing directions for how to add a new device - and I noticed that you could also just publish to the settings topic with the manually decoded IRK.