### PR TITLE
Add Mi Tag

### DIFF
--- a/beacons.md
+++ b/beacons.md
@@ -32,7 +32,7 @@ has_children: true
 | Innway Wallet Card   | [amazon](https://amzn.to/3Z8Govf)           | Rechargeable iBeacon - no need to use app or activate
 | Ultrahuman Ring      | [ultrahuman](https://www.ultrahuman.com/ring/) |
 | OpenHaystack-Beacons | [openhaystack-firmware](https://github.com/acalatrava/openhaystack-firmware/tree/main/apps/openhaystack-alternative) | Work outdoors with Apple's FindMy Network and are easily indoor-trackable
-
+| Xiaomi Mi Tags| [Ali Express](https://a.aliexpress.com/_msMm7sS)| If you pair them to the app, simply turn off Bluetooth long enough for it to start beeping, leave it disconnected after.
 ## Works with caveats
 
 | Name                 | Notes                                                                                                         |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new entry for "Xiaomi Mi Tags" in the beacons documentation, including a link to Ali Express and instructions on how to make them beep by turning off Bluetooth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->