### PR TITLE
Fix navigation to children of base station

### DIFF
--- a/enclosures.md
+++ b/enclosures.md
@@ -2,7 +2,7 @@
 layout: page
 title: Enclosures
 permalink: /enclosures
-parent: "Base Stations"
+parent: "Base Stations (Nodes)"
 nav_order: 7
 ---
 

--- a/firmware.md
+++ b/firmware.md
@@ -2,7 +2,7 @@
 layout: page
 title: Install Firmware
 permalink: /firmware
-parent: "Base Stations"
+parent: "Base Stations (Nodes)"
 nav_order: 2
 ---
 


### PR DESCRIPTION
Commit ebc12256cbd7d8e6eef5b1df2d2b2f1049563df7 changed the nav title from `Base Stations` to `Base Stations (Nodes)`, breaking the links to the sub pages in the nav. Currently there is no link to the firmware page on the site.

This keeps the new name and adds the links back in by referencing the correct parent.

![image](https://github.com/user-attachments/assets/168cc802-7394-4b8b-af61-5cf02a67c0f5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
	- Updated the categorization of content in the navigation structure for both `enclosures` and `firmware` sections, improving clarity by specifying "Base Stations (Nodes)".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->