### PR TITLE
Fix broken table on beacon page

### DIFF
--- a/beacons.md
+++ b/beacons.md
@@ -33,6 +33,7 @@ has_children: true
 | Ultrahuman Ring      | [ultrahuman](https://www.ultrahuman.com/ring/) |
 | OpenHaystack-Beacons | [openhaystack-firmware](https://github.com/acalatrava/openhaystack-firmware/tree/main/apps/openhaystack-alternative) | Work outdoors with Apple's FindMy Network and are easily indoor-trackable
 | Xiaomi Mi Tags| [Ali Express](https://a.aliexpress.com/_msMm7sS)| If you pair them to the app, simply turn off Bluetooth long enough for it to start beeping, leave it disconnected after.
+
 ## Works with caveats
 
 | Name                 | Notes                                                                                                         |


### PR DESCRIPTION
While I'm at it, I checked through the other pages and noticed the beacon page is broken: https://espresense.com/beacons

35844c8e708e64c1dcbb139f8acf324aa8ac3928 added a new table entry but no whitespace below between the table and the following heading. Adding one line of whitespace fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved visual clarity in the `beacons.md` file by adding a blank line before the "Works with caveats" section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->