### PR TITLE
Update android.md

### DIFF
--- a/android.md
+++ b/android.md
@@ -12,7 +12,6 @@ parent: Devices
 |:-----------------|:----------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------|
 | HA Companion App   | Yes/Recommended | [Playstore](https://play.google.com/store/apps/details?id=io.homeassistant.companion.android&hl=en_GB&gl=US) / [HA Documentation](https://companion.home-assistant.io/docs/core/sensors/#bluetooth-sensors) | Requires Home Assistant |
 | Beacon Scope       | Yes             | [Playstore](https://play.google.com/store/apps/details?id=com.davidgyoungtech.beaconscanner)                                                                                                                | Standalone App |
-|~~Beacon Simulator~~| ~~Yes~~         | ~~[Playstore](https://play.google.com/store/apps/details?id=net.alea.beaconsimulator)~~                                                                                                                     | ~~Standalone App~~ |
 
 ### Why an App?
 


### PR DESCRIPTION
Beacon Simulator by alea.net is no longer available in the app store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Android devices app support table to remove the "Beacon Simulator" app and improved alignment of remaining entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->