### PR TITLE
Switch Docker pulls badge to shields.io

### DIFF
--- a/companion/companion.md
+++ b/companion/companion.md
@@ -7,7 +7,7 @@ nav_order: 90
 # Companion
 
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/ESPresense/ESPresense-companion)
-![Docker Pulls](https://badgen.net/docker/pulls/espresense/espresense-companion)
+![Docker Pulls](https://img.shields.io/docker/pulls/espresense/espresense-companion)
 
 A Home Assistant Add-on / Docker container that solves indoor positions using MQTT data received from multiple ESPresense nodes. The companion is the central brain of your ESPresense system. It:
 - Processes distance readings from all nodes using trilateration to determine device locations


### PR DESCRIPTION
## Summary
- replace the Companion page's Docker pulls badge to use shields.io instead of badgen.net

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691609b49efc8324b963f3a345bcee77)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker badge source in documentation.

* **Chores**
  * Fixed file formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->