### PR TITLE
Add ESP32-C6 firmware JSON entries

### DIFF
--- a/public/firmware.manifest.json
+++ b/public/firmware.manifest.json
@@ -5,6 +5,7 @@
     { "name": "esp32c3.bin", "cpu": "esp32c3", "flavor": "" },
     { "name": "esp32c3-verbose.bin", "cpu": "esp32c3", "flavor": "verbose" },
     { "name": "esp32c6.bin", "cpu": "esp32c6", "flavor": "" },
+    { "name": "esp32c6-cdc.bin", "cpu": "esp32c6", "flavor": "cdc" },
     { "name": "esp32c6-verbose.bin", "cpu": "esp32c6", "flavor": "verbose" },
     { "name": "esp32s3.bin", "cpu": "esp32s3", "flavor": "" },
     { "name": "esp32s3-verbose.bin", "cpu": "esp32s3", "flavor": "verbose" },

--- a/public/firmware/types.json
+++ b/public/firmware/types.json
@@ -6,6 +6,9 @@
     { "name": "esp32c3.bin", "cpu": "esp32c3", "flavor": "" },
     { "name": "esp32c3-cdc.bin", "cpu": "esp32c3", "flavor": "cdc" },
     { "name": "esp32c3-verbose.bin", "cpu": "esp32c3", "flavor": "verbose" },
+    { "name": "esp32c6.bin", "cpu": "esp32c6", "flavor": "" },
+    { "name": "esp32c6-cdc.bin", "cpu": "esp32c6", "flavor": "cdc" },
+    { "name": "esp32c6-verbose.bin", "cpu": "esp32c6", "flavor": "verbose" },
     { "name": "esp32s3.bin", "cpu": "esp32s3", "flavor": "" },
     { "name": "esp32s3-cdc.bin", "cpu": "esp32s3", "flavor": "cdc" },
     { "name": "esp32s3-verbose.bin", "cpu": "esp32s3", "flavor": "verbose" },
@@ -15,9 +18,9 @@
     { "name": "macchina-a0.bin", "cpu": "esp32", "flavor": "macchina-a0" }
   ],
   "flavors": [
-    { "name": "Standard", "value": "", "cpus": ["esp32","esp32s3","esp32c3"] },
-    { "name": "Cdc", "value": "cdc", "cpus": ["esp32s3","esp32c3"] },
-    { "name": "Verbose", "value": "verbose", "cpus": ["esp32","esp32s3","esp32c3"] },
+    { "name": "Standard", "value": "", "cpus": ["esp32","esp32s3","esp32c3","esp32c6"] },
+    { "name": "Cdc", "value": "cdc", "cpus": ["esp32s3","esp32c3","esp32c6"] },
+    { "name": "Verbose", "value": "verbose", "cpus": ["esp32","esp32s3","esp32c3","esp32c6"] },
     { "name": "M5Atom", "value": "m5atom", "cpus": ["esp32"] },
     { "name": "M5StickC", "value": "m5stickc", "cpus": ["esp32"] },
     { "name": "M5StickC-plus", "value": "m5stickc-plus", "cpus": ["esp32"] },
@@ -26,6 +29,7 @@
   "cpus": [
     { "name": "ESP32", "value": "esp32" },
     { "name": "ESP32-S3", "value": "esp32s3" },
-    { "name": "ESP32-C3", "value": "esp32c3" }
+    { "name": "ESP32-C3", "value": "esp32c3" },
+    { "name": "ESP32-C6", "value": "esp32c6" }
   ]
 }


### PR DESCRIPTION
## Summary
- add static firmware entries for ESP32-C6 in `public/firmware/types.json`
- add ESP32-C6 CPU and flavor mappings so the installer can expose C6 variants
- add the missing `esp32c6-cdc.bin` entry to `public/firmware.manifest.json`

## Testing
- node -e "JSON.parse(require('fs').readFileSync('public/firmware.manifest.json','utf8')); JSON.parse(require('fs').readFileSync('public/firmware/types.json','utf8')); console.log('json ok')"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added firmware support for the ESP32-C6 microcontroller with three build variants
* Standard firmware build, CDC (Communications Device Class) build, and verbose diagnostics build now available for ESP32-C6
* Expanded all existing firmware flavor options to include ESP32-C6 platform support
* Users can now select from all available firmware variants when working with ESP32-C6 devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->