### PR TITLE
docs: refresh configuration reference against firmware v4.0.6

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -63,6 +63,7 @@ export default defineConfig({
             { slug: 'configuration/settings' },
             { slug: 'configuration/hardware' },
             { slug: 'configuration/mqtt' },
+            { slug: 'configuration/rest-api' },
           ],
         },
         {

--- a/src/content/docs/configuration/hardware.md
+++ b/src/content/docs/configuration/hardware.md
@@ -146,3 +146,7 @@ Configure a load cell amplifier.
 * Ensure GPIO pins don't conflict with other hardware functions
 * Addressable LEDs require proper power supply for multiple LEDs
 * Use appropriate timeout values to avoid false triggers on motion sensors
+
+---
+
+*Last verified against firmware v4.0.6 (`main` @ d9a1765, 2026-05-10).*

--- a/src/content/docs/configuration/mqtt.md
+++ b/src/content/docs/configuration/mqtt.md
@@ -86,8 +86,8 @@ mosquitto_pub -h homeassistant.local -u <username> -P <password> \
 | `skip_distance` | float (0–10) | `0.5` | Report immediately if the beacon has moved more than this (m). |
 | `skip_ms` | integer (0–3000000) | `5000` | Skip reporting if the message is younger than this (ms). Reduces MQTT chatter. |
 | `max_divisor` | integer (2–10) | `10` | Maximum divisor for the report interval. Larger movements divide `skip_ms` to report sooner. |
-| `forget_ms` | integer (0–3000000) | `150000` | Forget (drop) a fingerprint if not seen for this long (ms). |
-| `max_fingerprints` | integer (16–2048) | `100` (`200` on ESP32-S3/C3/C6) | Maximum number of tracked BLE fingerprints. Configured at boot only. |
+| `forget_ms` | integer (0–3000000) | `150000` | Forget (drop) a fingerprint if not seen for this long (ms). **Boot only** — not in the `Command()` dispatcher; writes to `<room>/forget_ms/set` are ignored. Set in the captive portal / Settings page and reboot. |
+| `max_fingerprints` | integer (16–2048) | `100` (`200` on ESP32-S3/C3/C6) | Maximum number of tracked BLE fingerprints. **Boot only.** |
 
 ### Calibration (RSSI)
 
@@ -95,7 +95,7 @@ mosquitto_pub -h homeassistant.local -u <username> -P <password> \
 |---|---|---|---|
 | `ref_rssi` | integer (-100 to 100) | `-65` | RSSI expected from a 0 dBm transmitter at 1 m. **Not** used for iBeacon / Eddystone (those carry their own calibrated RSSI). |
 | `tx_ref_rssi` | integer (-100 to 0) | `-59` | RSSI expected from this node's iBeacon transmit power at 1 m. |
-| `rx_adj_rssi` | integer (-100 to 100) | `0`* | Per-node receive RSSI adjustment. Use only when this board has a known-weak (or known-strong) antenna. <br>*Default `20` on ESP32-S3, `0` on everything else. |
+| `rx_adj_rssi` | integer (-100 to 100) | `0`* | Per-node receive RSSI adjustment. Use only when this board has a known-weak (or known-strong) antenna. <br>*Default `20` on bare ESP32-S3 builds; `0` on M5STICK and M5ATOM (even when S3-based — those board defines are matched before `ESP32S3` in `include/defaults.h:79-95`) and `0` on every other variant. |
 
 See [Calibration](/guides/calibration) for the full procedure.
 
@@ -108,19 +108,21 @@ See [Calibration](/guides/calibration) for the full procedure.
 | `known_macs` | string | `""` | Whitespace-separated BLE MACs (no colons, lowercase) treated as stable ids. Useful for devices that advertise a random-but-static MAC. Published as `known:<mac>`. |
 | `known_irks` | string | `""` | Whitespace-separated 32-hex-character IRKs for resolving Apple random-resolvable MACs into a stable id. See [Apple devices](/apple) for how to extract them. |
 | `query` | string | `""` | Whitespace-separated id prefixes to **actively connect** to over BLE and ask for Room Assistant / model / name characteristics. Example: `flora:` for Mi Flora plant sensors. |
-| `requery_ms` | integer seconds (30–3600) | `300` | How often to re-issue active queries against matched devices. |
+| `requery_ms` | integer seconds (30–3600) | `300` | How often to re-issue active queries against matched devices. **Boot only.** |
 | `connect_all` | ON / OFF | `OFF` | Allow active BLE connections to **every** device, bypassing the `query` filter. Intended for advanced debugging only — connecting to everything is expensive and can starve the scanner. |
 
 ### Counting
 
 The count feature publishes a sensor with the number of unique devices currently within the count window. Useful when you can't fingerprint individuals but the population count itself is informative (e.g. `exp:20` COVID exposure apps, generic `apple:`).
 
+Only `count_ids` is live-settable over MQTT. The three hysteresis knobs are read once at boot — set them in the captive portal / Settings page and reboot.
+
 | Setting | Type | Default | Description |
 |---|---|---|---|
 | `count_ids` | string | `""` | Whitespace-separated id prefixes to count. |
-| `count_enter` | float (0–100) | `2.0` | Start counting a device once it's closer than this (m). |
-| `count_exit` | float (0–100) | `4.0` | Stop counting once it's farther than this (m). Higher than `count_enter` creates hysteresis to prevent flapping. |
-| `count_ms` | integer ms (0–3000000) | `10000` | Stop counting a device if its last advertisement is older than this. |
+| `count_enter` | float (0–100) | `2.0` | Start counting a device once it's closer than this (m). **Boot only.** |
+| `count_exit` | float (0–100) | `4.0` | Stop counting once it's farther than this (m). Higher than `count_enter` creates hysteresis to prevent flapping. **Boot only.** |
+| `count_ms` | integer ms (0–3000000) | `10000` | Stop counting a device if its last advertisement is older than this. **Boot only.** |
 
 ### Network / MQTT
 

--- a/src/content/docs/configuration/mqtt.md
+++ b/src/content/docs/configuration/mqtt.md
@@ -7,7 +7,7 @@ sidebar:
 
 If you end up deploying a fleet of ESP32s in your home, it can quickly become painful to go to each device to update settings.
 
-You can use tools like [MQTT explorer](https://mqtt-explorer.com) or if you are using mosquitto (default for HA), the `mosquitto_sub` and `mosquitto_pub` tools to view and manage the settings.
+You can use tools like [MQTT explorer](https://mqtt-explorer.com) or if you are using mosquitto (default for Home Assistant), the `mosquitto_sub` and `mosquitto_pub` tools to view and manage the settings.
 
 
 ```bash
@@ -15,141 +15,277 @@ mosquitto_sub -h homeassistant.local -u <username> -P <password> -v -t "espresen
 ```
 
 :::note
-For configuration of the Companion App also check the [Companion MQTT](/companion/installation/#mqtt-setup) section
+For configuration of the Companion App also check the [Companion MQTT](/companion/installation/#mqtt-setup) section.
 :::
 
-## Reading Current Settings
+## Topic shape
 
-Example output when subscribing to a room:
+The firmware uses one base topic prefix, `espresense`, hard-coded as the `CHANNEL`. Everything below that is built up from your room slug:
+
 ```
-espresense/rooms/study/status online
-espresense/rooms/study/max_distance 10.00
-espresense/rooms/study/absorption 3.50
-espresense/rooms/study/include apple:aaaayyyy iBeacon:232323
-espresense/rooms/study/exclude sonos:xxxx sonos:yyyy
-espresense/rooms/study/auto_update OFF
-espresense/rooms/study/prerelease OFF
-espresense/rooms/study/arduino_ota OFF
+espresense/rooms/<room>/<key>           # node-side state / settings (retained)
+espresense/rooms/<room>/<key>/set       # write a setting (publish to this)
+espresense/rooms/<room>/telemetry       # JSON metrics (non-retained)
+espresense/rooms/<room>/status          # online / offline (LWT, retained)
+espresense/devices/<id>/<room>          # per-device distance (when pub_devices=on)
+espresense/settings/<id>/config         # global device-config (Companion writes here)
 ```
 
-## Updating Settings
+`<room>` is the room name, slugified (uppercase/spaces are normalised to a slug).
 
-You can update the configuration for any of the above topics by publishing to the `/set` endpoint for each topic like so:
+A `<room>` of `*` matches every node and is the recommended way to roll a setting out to a fleet. Publish with the **retain** flag set on `*` topics and newly-joining nodes will also pick up that setting at startup.
+
+## Reading current settings
+
+When a node connects, it publishes a retained snapshot of its current settings under `espresense/rooms/<room>/...`. Subscribe to the room to see them:
+
+```text
+espresense/rooms/study/status        online
+espresense/rooms/study/name          Study
+espresense/rooms/study/max_distance  16.0
+espresense/rooms/study/absorption    2.7
+espresense/rooms/study/tx_ref_rssi   -59
+espresense/rooms/study/rx_adj_rssi   0
+espresense/rooms/study/query
+espresense/rooms/study/include       apple:aaaayyyy iBeacon:232323
+espresense/rooms/study/exclude       sonos:xxxx sonos:yyyy
+espresense/rooms/study/known_macs    aabbccddeeff 112233445566
+espresense/rooms/study/known_irks
+espresense/rooms/study/count_ids
+espresense/rooms/study/auto_update   OFF
+espresense/rooms/study/prerelease    OFF
+espresense/rooms/study/arduino_ota   OFF
+```
+
+Sensor and GPIO state (when configured) also appears under the same room prefix — see [Published topics](#published-topics) below.
+
+## Updating settings
+
+Publish to `<key>/set` to change a setting on one node:
 
 ```bash
-mosquitto_pub -h homeassistant.local -u <username> -P <password> -t "espresense/rooms/kitchen/auto_update/set" -m "ON" -d
+mosquitto_pub -h homeassistant.local -u <username> -P <password> \
+  -t "espresense/rooms/kitchen/auto_update/set" -m "ON" -d
 ```
 
-You can use a room of `*` to update all ESPresense nodes at the same time. If you retain that setting even NEW nodes will upon startup get that configuration set.
+Use a room of `*` to update every ESPresense node at once. Add `-r` (retain) and new nodes joining later will apply the same value on first boot:
 
-## Available Configuration Options
+```bash
+mosquitto_pub -h homeassistant.local -u <username> -P <password> \
+  -t "espresense/rooms/*/absorption/set" -m "3.0" -r
+```
 
-### Core BLE Settings
+## Settings reference
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `max_distance` | float | 16.0 | Maximum distance to report (in meters). Devices beyond this distance are filtered out. |
-| `absorption` | float | 2.7 | Factor used to account for signal absorption, reflection, or diffraction. Adjust based on your environment. |
-| `skip_distance` | float | 0.5 | Report early if beacon has moved more than this distance (in meters). |
-| `skip_ms` | integer | 5000 | Skip reporting if message age is less than this (in milliseconds). Reduces MQTT traffic. |
-| `max_divisor` | integer | 10 | Max divisor for reporting interval. Larger movements divide the skip interval. |
-
-### RSSI Calibration Settings
+### Core BLE
 
 | Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `ref_rssi` | integer | -65 | RSSI expected from a 0dBm transmitter at 1 meter. NOT used for iBeacons or Eddystone. |
-| `tx_ref_rssi` | integer | -59 | RSSI expected from this tx power at 1m (used for node iBeacon transmission). |
-| `rx_adj_rssi` | integer | 0* | RSSI adjustment for receiver (use only if you know this device has a weak antenna). *Default varies by board: ESP32S3=20, others=0 |
+|---|---|---|---|
+| `max_distance` | float (0–100) | `16.0` | Maximum distance (m) to report. Devices computed beyond this are dropped. |
+| `absorption` | float (1–5) | `2.7` | Environmental absorption / path-loss factor. Higher = signal attenuates faster. |
+| `skip_distance` | float (0–10) | `0.5` | Report immediately if the beacon has moved more than this (m). |
+| `skip_ms` | integer (0–3000000) | `5000` | Skip reporting if the message is younger than this (ms). Reduces MQTT chatter. |
+| `max_divisor` | integer (2–10) | `10` | Maximum divisor for the report interval. Larger movements divide `skip_ms` to report sooner. |
+| `forget_ms` | integer (0–3000000) | `150000` | Forget (drop) a fingerprint if not seen for this long (ms). |
+| `max_fingerprints` | integer (16–2048) | `100` (`200` on ESP32-S3/C3/C6) | Maximum number of tracked BLE fingerprints. Configured at boot only. |
 
-### Device Filtering
-
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `include` | string | (empty) | Include only sending these IDs to MQTT (space-separated). Example: `apple:iphone10-6 apple:iphone13-2` |
-| `exclude` | string | (empty) | Exclude sending these IDs to MQTT (space-separated). Example: `exp:20 apple:iphone10-6` |
-| `known_macs` | string | (empty) | Known BLE MAC addresses (no colons, space-separated). These devices get special handling. |
-| `known_irks` | string | (empty) | Known BLE Identity Resolving Keys (32 hex chars, space-separated) for Apple device tracking. |
-| `query` | string | (empty) | Query device IDs for characteristics. Example: `flora:` for Xiaomi Mi Flora devices. |
-
-### Counting Settings
+### Calibration (RSSI)
 
 | Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `count_ids` | string | (empty) | Include ID prefixes for counting (space-separated). Devices matching these prefixes are counted. |
+|---|---|---|---|
+| `ref_rssi` | integer (-100 to 100) | `-65` | RSSI expected from a 0 dBm transmitter at 1 m. **Not** used for iBeacon / Eddystone (those carry their own calibrated RSSI). |
+| `tx_ref_rssi` | integer (-100 to 0) | `-59` | RSSI expected from this node's iBeacon transmit power at 1 m. |
+| `rx_adj_rssi` | integer (-100 to 100) | `0`* | Per-node receive RSSI adjustment. Use only when this board has a known-weak (or known-strong) antenna. <br>*Default `20` on ESP32-S3, `0` on everything else. |
 
-### Update/OTA Settings
+See [Calibration](/guides/calibration) for the full procedure.
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `auto_update` | ON/OFF | OFF | Automatically update firmware when new releases are available. |
-| `prerelease` | ON/OFF | OFF | Include pre-released versions in auto-update checks. |
-| `arduino_ota` | ON/OFF | OFF | Enable Arduino OTA updates (allows updating via Arduino IDE). |
-| `update` | string | (empty) | If set to a URL, device will update from this URL on next boot. |
-
-### Motion Sensor Settings
+### Scanning / filtering
 
 | Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `pir_timeout` | float | 0.5 | PIR motion timeout in seconds (debounce time). |
-| `radar_timeout` | float | 0.5 | Radar motion timeout in seconds (debounce time). |
+|---|---|---|---|
+| `include` | string | `""` | Whitespace-separated allow-list of device id prefixes. If set, ONLY matching ids are published. Example: `apple:iphone10-6 apple:iphone13-2`. |
+| `exclude` | string | `""` | Whitespace-separated deny-list of device id prefixes. Filtered out before publish. Example: `exp:20 apple:iphone10-6`. |
+| `known_macs` | string | `""` | Whitespace-separated BLE MACs (no colons, lowercase) treated as stable ids. Useful for devices that advertise a random-but-static MAC. Published as `known:<mac>`. |
+| `known_irks` | string | `""` | Whitespace-separated 32-hex-character IRKs for resolving Apple random-resolvable MACs into a stable id. See [Apple devices](/apple) for how to extract them. |
+| `query` | string | `""` | Whitespace-separated id prefixes to **actively connect** to over BLE and ask for Room Assistant / model / name characteristics. Example: `flora:` for Mi Flora plant sensors. |
+| `requery_ms` | integer seconds (30–3600) | `300` | How often to re-issue active queries against matched devices. |
+| `connect_all` | ON / OFF | `OFF` | Allow active BLE connections to **every** device, bypassing the `query` filter. Intended for advanced debugging only — connecting to everything is expensive and can starve the scanner. |
 
-### Switch Settings
+### Counting
+
+The count feature publishes a sensor with the number of unique devices currently within the count window. Useful when you can't fingerprint individuals but the population count itself is informative (e.g. `exp:20` COVID exposure apps, generic `apple:`).
 
 | Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `switch_1_timeout` | float | 0.5 | Switch One timeout in seconds (debounce time). |
-| `switch_2_timeout` | float | 0.5 | Switch Two timeout in seconds (debounce time). |
+|---|---|---|---|
+| `count_ids` | string | `""` | Whitespace-separated id prefixes to count. |
+| `count_enter` | float (0–100) | `2.0` | Start counting a device once it's closer than this (m). |
+| `count_exit` | float (0–100) | `4.0` | Stop counting once it's farther than this (m). Higher than `count_enter` creates hysteresis to prevent flapping. |
+| `count_ms` | integer ms (0–3000000) | `10000` | Stop counting a device if its last advertisement is older than this. |
 
-### Button Settings
+### Network / MQTT
+
+These are configured at boot (over the captive portal / Network page) and **cannot** be set live over MQTT — restart-flashing only.
 
 | Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `button_1_timeout` | float | 0.5 | Button One timeout in seconds (debounce time). |
-| `button_2_timeout` | float | 0.5 | Button Two timeout in seconds (debounce time). |
+|---|---|---|---|
+| `wifi-ssid` | string | (empty) | Wi-Fi SSID. Can also be re-written via MQTT (`<room>/wifi-ssid/set`). |
+| `wifi-password` | string | (empty) | Wi-Fi password. Same MQTT setter as above. |
+| `wifi_timeout` | integer seconds | `60` | Seconds to wait for Wi-Fi before falling back to the captive portal. `-1` = wait forever. |
+| `portal_timeout` | integer seconds | `300` | Seconds to keep the captive portal up before rebooting and retrying Wi-Fi. |
+| `mqtt_host` | string | (build default) | MQTT broker hostname or IP. SSL is not supported. |
+| `mqtt_port` | integer | `1883` | MQTT broker port. |
+| `discovery` | checkbox | `ON` | Publish Home Assistant MQTT-discovery payloads on connect. |
+| `discovery_prefix` | string | `homeassistant` | Home Assistant discovery prefix. Only change if your HA install uses a non-default prefix. |
+| `pub_tele` | checkbox | `ON` | Publish to `<room>/telemetry` (uptime, free heap, scan counters, etc.). |
+| `pub_devices` | checkbox | `ON` | Publish per-device distances to `espresense/devices/<id>/<room>` (the flat per-device topic shape). |
 
-### System Commands
+### Updates / OTA
 
-| Setting | Type | Description |
-|---------|------|-------------|
-| `restart` | button | Restart the device immediately. |
-| `name` | string | Change the room name (slugified to create device ID). |
+| Setting | Type | Default | Description |
+|---|---|---|---|
+| `auto_update` | ON / OFF | `OFF` | Check GitHub for new firmware on a 15-minute interval and auto-flash if available. |
+| `prerelease` | ON / OFF | `OFF` | Include pre-release builds when auto-checking. |
+| `arduino_ota` | ON / OFF | `OFF` | Enable the Arduino OTA protocol (espota / PlatformIO). Keep off for less RAM use and a smaller attack surface. |
+| `update` | string URL | `""` | If set, the node fetches firmware from this URL on next boot. Cleared after a successful update. |
 
-### Enrollment Commands
+### Motion / Switch / Button
 
-| Setting | Type | Description |
-|---------|------|-------------|
-| `enroll` | string | Start BLE device enrollment mode. Format: `id\|name` or just `name`. Device stays in enrollment mode for 2 minutes. |
-| `cancelEnroll` | button | Cancel enrollment mode. |
+Pin assignments live on the [Hardware](/configuration/hardware) page; the timeouts can be tuned at runtime.
+
+| Setting | Type | Default | Description |
+|---|---|---|---|
+| `pir_timeout` | float seconds (0–300) | `0.5` | PIR debounce / hold time after the last trigger. |
+| `radar_timeout` | float seconds (0–300) | `0.5` | Radar debounce / hold time after the last trigger. |
+| `switch_1_timeout` | float seconds (0–300) | `0.5` | Switch One debounce. |
+| `switch_2_timeout` | float seconds (0–300) | `0.5` | Switch Two debounce. |
+| `button_1_timeout` | float seconds (0–300) | `0.5` | Button One debounce. |
+| `button_2_timeout` | float seconds (0–300) | `0.5` | Button Two debounce. |
+
+### Commands
+
+| Topic | Payload | Action |
+|---|---|---|
+| `<room>/restart/set` *(or `reboot/set`)* | (any) | Restart the node immediately. |
+| `<room>/name/set` | string | Rename the room. Slugified to form the device id. Empty payload resets to the MAC. |
+| `<room>/enroll/set` | `id\|name` or `name` or `PRESS` | Enter BLE enrollment mode for 2 minutes. See [Apple devices → Enrollment](/apple/#enrollment-easiest). |
+| `<room>/cancelEnroll/set` | (any) | Leave enrollment mode immediately. |
+
+## Published topics
+
+All topics under `espresense/rooms/<room>/...` are retained unless noted.
+
+### Status
+
+| Topic | Payload | Notes |
+|---|---|---|
+| `status` | `online` / `offline` | LWT — `offline` is published automatically on disconnect. |
+| `name` | string | Current room display name. |
+| `telemetry` | JSON | Non-retained. Includes `uptime`, `freeHeap`, scan counters, and `count` when `count_ids` is set. |
+
+### Settings snapshot (on connect)
+
+Republished retained when the node comes back online so a fresh subscriber sees the current values:
+
+`max_distance`, `absorption`, `tx_ref_rssi`, `rx_adj_rssi`, `query`, `include`, `exclude`, `known_macs`, `known_irks`, `count_ids`, plus updater state (`auto_update`, `prerelease`, `arduino_ota`) and per-input timeouts when those sensors are enabled.
+
+### GPIO sensors
+
+Published when the corresponding pin is configured ([Hardware](/configuration/hardware)):
+
+| Topic | Payload | Notes |
+|---|---|---|
+| `pir` | `ON` / `OFF` | Raw PIR state. |
+| `radar` | `ON` / `OFF` | Raw radar state. |
+| `motion` | `ON` / `OFF` | Logical OR of pir + radar. Use this in Home Assistant automations. |
+| `switch_1`, `switch_2` | `ON` / `OFF` | Individual switch state. |
+| `switch` | `ON` / `OFF` | Logical OR of both switches. |
+| `button_1`, `button_2` | `ON` / `OFF` | Individual button state. |
+| `button` | `ON` / `OFF` | Logical OR of both buttons. |
+
+### LEDs
+
+When a configured LED has **LED Control = MQTT** ([Hardware → MQTT LED control](/configuration/hardware/#mqtt-led-control-v40)):
+
+| Topic | Payload | Notes |
+|---|---|---|
+| `led_1`, `led_2`, `led_3` | JSON state | Published when the LED changes. |
+| `led_1/set`, `led_2/set`, `led_3/set` | JSON command | See the LED control example below. |
+
+### Per-device topics
+
+When `pub_devices` is on (default), each tracked device is published to a flat topic under `espresense/devices/`:
+
+```
+espresense/devices/<device-id>/<room>          # JSON: id, distance, rssi, name, …
+espresense/devices/<device-id>/<room>/<report> # individual sub-reports (rare)
+```
+
+Payloads are non-retained. The top-level topic carries a single JSON object — the same shape `GET /json/devices` returns for one device. `<device-id>` is whatever the node settled on (`apple:iphone15-3`, `irk:…`, `known:…`, `iBeacon:…`, etc.). This is the topic shape Home Assistant's `mqtt_room` integration consumes.
+
+### Subscribed topics
+
+The firmware subscribes to three topics on connect:
+
+| Topic | Used for |
+|---|---|
+| `espresense/rooms/*/+/set` | Fleet-wide setting writes (the `*` wildcard). |
+| `espresense/rooms/<this-room>/+/set` | Per-node setting writes. |
+| `espresense/settings/+/config` | Device-level enrollment configs published by the Companion (or by `POST /json/configs`). The `+` is the device id; the payload is the same JSON used by [REST `/json/configs`](/configuration/rest-api/#postjson-configs). |
 
 ## Examples
 
 ### Filter to only track Apple devices
+
 ```bash
-mosquitto_pub -h homeassistant.local -u <username> -P <password> -t "espresense/rooms/kitchen/include/set" -m "apple:"
+mosquitto_pub -h homeassistant.local -u <username> -P <password> \
+  -t "espresense/rooms/kitchen/include/set" -m "apple:"
 ```
 
 ### Set maximum distance to 10 meters
+
 ```bash
-mosquitto_pub -h homeassistant.local -u <username> -P <password> -t "espresense/rooms/kitchen/max_distance/set" -m "10.0"
+mosquitto_pub -h homeassistant.local -u <username> -P <password> \
+  -t "espresense/rooms/kitchen/max_distance/set" -m "10.0"
 ```
 
-### Enable auto-update on all nodes
+### Enable auto-update on every node (and new joiners)
+
 ```bash
-mosquitto_pub -h homeassistant.local -u <username> -P <password> -t "espresense/rooms/*/auto_update/set" -m "ON" -r
+mosquitto_pub -h homeassistant.local -u <username> -P <password> \
+  -t "espresense/rooms/*/auto_update/set" -m "ON" -r
 ```
 
-### Adjust RSSI for a node with weak antenna
+### Adjust RSSI for a node with a weak antenna
+
 ```bash
-mosquitto_pub -h homeassistant.local -u <username> -P <password> -t "espresense/rooms/kitchen/rx_adj_rssi/set" -m "10"
+mosquitto_pub -h homeassistant.local -u <username> -P <password> \
+  -t "espresense/rooms/kitchen/rx_adj_rssi/set" -m "10"
 ```
 
 ### Start enrollment for a new device
+
 ```bash
-mosquitto_pub -h homeassistant.local -u <username> -P <password> -t "espresense/rooms/kitchen/enroll/set" -m "myphone:abcdef|My Phone"
+mosquitto_pub -h homeassistant.local -u <username> -P <password> \
+  -t "espresense/rooms/kitchen/enroll/set" -m "myphone:abcdef|My Phone"
 ```
 
-### Update all nodes simultaneously
+### Update absorption everywhere
+
 ```bash
-mosquitto_pub -h homeassistant.local -u <username> -P <password> -t "espresense/rooms/*/absorption/set" -m "3.0" -r
+mosquitto_pub -h homeassistant.local -u <username> -P <password> \
+  -t "espresense/rooms/*/absorption/set" -m "3.0" -r
 ```
+
+### Control an MQTT-mode LED
+
+```bash
+mosquitto_pub -h homeassistant.local -u <username> -P <password> \
+  -t "espresense/rooms/kitchen/led_1/set" \
+  -m '{"state":"ON","brightness":64,"color":{"r":255,"g":128,"b":0}}'
+```
+
+Accepted JSON keys: `state` (`ON`/`OFF`), `brightness` (0–255), `color.r`/`g`/`b`, `white_value` (0–255), `color_temp`, and `effect`. Supported keys depend on the LED's color mode.
+
+---
+
+*Last verified against firmware v4.0.6 (`main` @ d9a1765, 2026-05-10).*

--- a/src/content/docs/configuration/network.md
+++ b/src/content/docs/configuration/network.md
@@ -7,32 +7,41 @@ sidebar:
 
 <img src="/images/network_screen.png" alt="Screenshot of ESP32 initial settings interface" style="float:right;margin-left:20px;width:340px" />
 
-The ESP32 will launch a captive browser (under its own SSID) on first normal boot after flashing that will allow you to configure network settings. These settings are accessible from the **Network** page in the device web UI.
+On first boot after flashing, the ESP32 launches a captive Wi-Fi portal under its own SSID. Join it, enter your network and MQTT credentials, and the device will reboot onto your network. These same fields stay editable from the **Network** page in the device web UI.
 
 ## Room Configuration
-* Room name - This is the name that will identify this sensor in Home Assistant, as well as the state of mqtt_room sensor. Use a upper/lower word and we'll slugify it for the places that need that
+
+* **Room name** — used as the node's identity in Home Assistant and as the `<room>` segment of every MQTT topic. Spaces and case are normalised to a slug for the topic; the original is preserved for display.
 
 ## Wi-Fi Configuration
-* Wi-Fi SSID - Enter Wi-Fi SSID
-* Available Networks - Dynamic list of available networks
-* Wi-Fi Password - Enter Wi-Fi Password
-* Seconds to wait in captive portal before reboot
-* Ethernet Type - Select your ethernet connection type if applicable
+
+* **Wi-Fi SSID** — the network to join.
+* **Available Networks** — live scan list.
+* **Wi-Fi Password** — WPA2 passphrase. Stored unencrypted on the device.
+* **Seconds to wait for WiFi before captive portal** (`wifi_timeout`, default `60`s) — `-1` waits forever instead of falling back to the portal.
+* **Seconds to wait in captive portal before reboot** (`portal_timeout`, default `300`s).
+* **Ethernet Type** — select your Ethernet connection type if the board has an Ethernet PHY (Olimex POE, M5Stack PoE Atom, etc.). Leave blank for Wi-Fi-only nodes.
 
 ## MQTT Configuration
-* Server - MQTT Broker address (e.g. mqtt.example.com) non-encrypted MQTT server (SSL is NOT supported)
-* Port - MQTT Broker port (e.g. 1883)
-* Username - Optional. Note: Since MQTT connections are unencrypted, these credentials will be transmitted in plaintext. Consider using these only in trusted networks.
-* Password - Optional.
-* Send to discovery topic - enables home assistant mqtt topic (/homeassistant)
-* Home Assistant discovery topic prefix - customize the discovery topic prefix
-* Send to telemetry topic - enables stats about availability also used by counting
-* Send to devices topic - instead of all mashed together topic, this adds a device to the path (much easier to understand in mqtt explorer)
+
+* **Server** — MQTT broker hostname or IP (e.g. `mqtt.example.com`). **TLS is not supported**; the connection is plaintext.
+* **Port** — broker port (`mqtt_port`, default `1883`).
+* **Username** — optional. Because the link is unencrypted, credentials transit in plaintext — only use these on trusted networks.
+* **Password** — optional.
+* **Send to discovery topic** (`discovery`, default on) — publish Home Assistant MQTT-discovery payloads on connect.
+* **Home Assistant discovery topic prefix** (`discovery_prefix`, default `homeassistant`) — only change if your HA install uses a non-default prefix.
+* **Send to telemetry topic** (`pub_tele`, default on) — emit `<room>/telemetry` JSON (uptime, free heap, scan counters). Required for the count sensor.
+* **Send to devices topic** (`pub_devices`, default on) — emit per-device distances to `espresense/devices/<id>/<room>`. This is the topic shape Home Assistant's `mqtt_room` integration consumes.
 
 ## Updating
-* Automatically update - If enabled we'll ask github for the latest version and if it's not the same version as current update to it
-* Include pre-release versions in auto-update - Modifies the above check to include pre-release versions
-* Arduino OTA Update - If enabled you can remotely flash this device using the standard (espota/arduino) protocol. Keep disabled for less memory usage, and security.
-* Update URL - If set will update from this url on next boot
 
-For additional configuration options like scanning, counting, filtering, and calibration, see the [Settings](settings) page. For LED and GPIO sensor configuration, see the [Hardware](hardware) page.
+* **Automatically update** (`auto_update`) — check GitHub for new firmware on a 15-minute interval and flash if available.
+* **Include pre-release versions in auto-update** (`prerelease`) — also accept pre-release builds.
+* **Arduino OTA Update** (`arduino_ota`) — enable the Arduino OTA / espota protocol. Keep off for less RAM use and a smaller attack surface.
+* **Update URL** (`update`) — if set, the node fetches firmware from this URL on next boot. Cleared after a successful update.
+
+For scanning, counting, filtering, and calibration options, see [Settings](/configuration/settings). For LED and GPIO sensors, see [Hardware](/configuration/hardware). For the full MQTT topic list (including every setting in this page) see [MQTT](/configuration/mqtt).
+
+---
+
+*Last verified against firmware v4.0.6 (`main` @ d9a1765, 2026-05-10).*

--- a/src/content/docs/configuration/rest-api.md
+++ b/src/content/docs/configuration/rest-api.md
@@ -1,0 +1,148 @@
+---
+title: REST API
+sidebar:
+  order: 5
+---
+
+
+Each ESPresense node runs a small HTTP server on its Wi-Fi address. The web UI uses it, the Companion calls it, and you can call it directly when scripting an install.
+
+The API is unauthenticated and CORS-open (`Access-Control-Allow-Origin: *`). Treat the node like any other unauthenticated device on your LAN — keep it off the public internet.
+
+The base URL is `http://<node-ip>` or `http://<node-hostname>.local` (mDNS, when enabled). Examples below use `kitchen.local`.
+
+## Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/json` | Node info: room name, firmware version, board variant. |
+| `GET` | `/json/devices` | Currently-tracked devices with distance, RSSI, and id. |
+| `GET` | `/json/devices?showAll=1` | Same, plus invisible/filtered devices marked with `"vis": true`. |
+| `GET` | `/json/configs` | Enrolled device configs (`id`, `alias`, `name`, `rssi@1m`). |
+| `POST` | `/json/configs` | Add or update an enrolled device config. |
+| `DELETE` | `/json/configs?id=<id>` | Remove an enrolled device config by id. |
+| `POST` | `/restart` *(or `/reboot`)* | Restart the node. |
+| WebSocket | `/ws` | Live state stream (room name, enrollment status). Used by the web UI. |
+
+The static web UI (Svelte / SvelteKit) is served from `/` and its sub-paths (`/ui/...`) — those are not part of the REST surface.
+
+## `GET /json`
+
+```bash
+curl http://kitchen.local/json
+```
+
+```json
+{
+  "room": "Kitchen",
+  "ver": "4.0.6",
+  "firm": "esp32"
+}
+```
+
+`ver` and `firm` are present when the build set the `VERSION` and `FIRMWARE` macros (which the released artifacts always do; manual local builds may omit them).
+
+## `GET /json/devices`
+
+```bash
+curl http://kitchen.local/json/devices
+```
+
+```json
+{
+  "room": "Kitchen",
+  "ver": "4.0.6",
+  "firm": "esp32",
+  "devices": [
+    {
+      "id": "apple:iphone15-3",
+      "name": "Dan's iPhone",
+      "rssi@1m": -59,
+      "rssi": -71,
+      "distance": 2.4,
+      "mac": "aabbccddeeff",
+      "...": "..."
+    }
+  ]
+}
+```
+
+Each entry is one currently-tracked BLE fingerprint. The full shape is what `BleFingerprint::fill()` emits — id, friendly name (if known), MAC, computed distance in meters, last-seen RSSI, calibrated RSSI@1m, and signal-source flags.
+
+Add `?showAll=1` to include fingerprints that are normally suppressed by `include` / `exclude` / `max_distance` filtering. Suppressed entries are tagged `"vis": true` so you can distinguish them.
+
+## `GET /json/configs`
+
+```bash
+curl http://kitchen.local/json/configs
+```
+
+```json
+{
+  "room": "Kitchen",
+  "ver": "4.0.6",
+  "firm": "esp32",
+  "configs": [
+    { "id": "apple:iphone15-3", "alias": "dans-iphone", "name": "Dan's iPhone", "rssi@1m": -59 },
+    { "id": "irk:abcdef0123456789abcdef0123456789", "alias": "watch", "name": "Dan's Watch" }
+  ]
+}
+```
+
+`rssi@1m` is omitted when the device hasn't been calibrated.
+
+## `POST /json/configs`
+
+Add or update an enrollment. The body is JSON.
+
+```bash
+curl -X POST http://kitchen.local/json/configs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "apple:iphone15-3",
+    "alias": "dans-iphone",
+    "name": "Dan'\''s iPhone",
+    "rssi@1m": -59
+  }'
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | yes | The fingerprint id to bind to (`apple:...`, `irk:...`, `known:...`, etc.). |
+| `alias` | string | no | Stable id to publish under instead of `id`. Defaults to `id` when omitted. |
+| `name` | string | no | Friendly name (shown in the web UI). |
+| `rssi@1m` | integer | no | Calibrated 1-meter RSSI for this device. Omit (or send `-128`) for "uncalibrated". |
+
+Response: `{"success": true}` (HTTP 200) on save; HTTP 400 / 500 with `{"error":"..."}` on bad input or storage failure.
+
+Saved configs are propagated to the whole fleet via the retained MQTT topic `espresense/settings/<id>/config` ([MQTT subscribed topics](/configuration/mqtt/#subscribed-topics)).
+
+## `DELETE /json/configs`
+
+```bash
+curl -X DELETE "http://kitchen.local/json/configs?id=apple:iphone15-3"
+```
+
+Removes the enrollment locally and clears the retained MQTT settings entry (so other nodes drop it too). Response shape matches `POST` — `{"success":true}` or `{"error":"..."}`.
+
+## `POST /restart`
+
+```bash
+curl -X POST http://kitchen.local/restart
+```
+
+Returns `Restarting...` (text/plain) and reboots. `/reboot` is an alias.
+
+## WebSocket `/ws`
+
+The web UI opens a WebSocket to receive live state updates while you watch the device. Messages are JSON and currently carry:
+
+```json
+{ "state": { "enrolling": true, "remain": 117 }, "room": "Kitchen", "ver": "4.0.6" }
+```
+
+`enrolledId` is included when the most recent enroll succeeded. Clients can send `{"command":"enroll","payload":"name"}` or `{"command":"cancelEnroll"}` over the socket — both map to the same handler as the MQTT [enrollment commands](/configuration/mqtt/#commands).
+
+---
+
+*Last verified against firmware v4.0.6 (`main` @ d9a1765, 2026-05-10).*

--- a/src/content/docs/configuration/settings.md
+++ b/src/content/docs/configuration/settings.md
@@ -7,41 +7,57 @@ sidebar:
 
 <img src="/images/settings_screen.png" alt="Screenshot of ESP32 full settings interface" style="float:right;margin-left:20px;width:340px" />
 
-These settings are accessible from the **Settings** page in the device web UI.
+These settings are accessible from the **Settings** page in the device web UI. They can also be written live over [MQTT](/configuration/mqtt) — defaults and ranges for every option are listed in the [MQTT settings reference](/configuration/mqtt/#settings-reference).
 
 ## Scanning
-* Known BLE mac addresses (no colons, space separated) - If you have a device that uses a random ble mac BUT it doesn't actually change the mac periodically you can just put it here and we'll use the id `known:{mac}`
-* Known BLE identity resolving keys, should be 32 hex chars space separated
-* Forget beacon if not seen for (in milliseconds) - How long to keep idle devices before removing them.
+
+* **Known BLE mac addresses** (no colons, space separated) — devices that use a random-but-static MAC. ESPresense publishes them with the stable id `known:{mac}`.
+* **Known BLE identity resolving keys** — 32-hex-character IRKs (space separated) that let ESPresense recognise Apple devices through their address rotation. See [Apple devices](/apple) for extraction tips.
+* **Forget beacon if not seen for (in milliseconds)** — drop idle fingerprints (`forget_ms`, default `150000` ms = 2.5 minutes).
+* **Maximum BLE fingerprints to track** — caps fingerprint memory at boot (`max_fingerprints`, default `100`; `200` on ESP32-S3/C3/C6).
+* **Allow active BLE connections to all devices** — `connect_all`. Bypasses the `query` allow-list and connects to everything. Expensive and rarely useful outside protocol debugging.
 
 ## Querying
-We use the best id we can figure out based on passively listening to device advertisements, but sometimes you want an even better id. Query enables the ESP to connect to the device and ask it questions. Currently we ask for the room assistant id, model, and name. If we get useful answers back we will upgrade the id to the most selective one.
 
-* Query device ids for characteristics (eg. flora:)
-* Requery interval in seconds
+Most BLE devices give a usable id from passive advertisements alone, but some need an active GATT connection to identify themselves. **Query** opens that connection and reads the Room Assistant id, model, and name characteristics. When the device responds, ESPresense upgrades to the most-selective id available.
+
+* **Query device ids for characteristics** — id-prefix allow-list (`query`), e.g. `flora:` for Xiaomi Mi Flora plant sensors.
+* **Requery interval in seconds** — re-issue the active query every N seconds (`requery_ms`, default `300`, range 30–3600).
 
 ## Counting
-This is a beta feature for the use case where a device fingerprint doesn't come up with a unique device, but you can glean useful info from the number of unique MACs that are currently broadcasting within a certain distance of the base station. This is most useful for `exp:20` (COVID exposure apps), `Apple:` (Apple devices), or `Microsoft:cdp` (Microsoft devices). Once configured, auto-discovery will add a count sensor to your ESPresense device.
 
-* **Include ID prefixes (space separated)** - List of prefixes to include in the count.
-* **Start counting devices less than distance (in meters)** - "Enter" distance: device counts when closer than this.
-* **Stop counting devices greater than distance (in meters)** - "Leave" distance: device stops counting when further than this. Setting this higher than the start distance creates a hysteresis zone to prevent rapid toggling.
-* **Include devices with age less than (in ms)** - Since we're just getting stateless advertisements, we also need the device to "LEAVE" if not seen within a certain amount of time.
+A beta feature for devices that you can't fingerprint individually but where the *count* itself is useful — `exp:20` (COVID exposure apps), `apple:` (anonymous Apple devices), `Microsoft:cdp` (Microsoft devices). When set, auto-discovery adds a count sensor to your ESPresense node.
+
+* **Include ID prefixes** (`count_ids`).
+* **Start counting devices less than distance** (m) — "enter" radius (`count_enter`, default `2.0`).
+* **Stop counting devices greater than distance** (m) — "leave" radius (`count_exit`, default `4.0`). Setting this above the enter radius creates a hysteresis band that prevents flapping.
+* **Include devices with age less than** (ms) — drop a device from the count if its last advertisement is older than this (`count_ms`, default `10000`).
 
 ## Filtering
-* **Include only sending these IDs to MQTT (e.g., Apple:iphone10-6 Apple:iphone13-2)** - If set, ONLY IDs that match this come to MQTT.
-* **Exclude sending these IDs to MQTT (e.g., exp:20 Apple:iphone10-6)** - If set, will filter out just these IDs.
-* **Maximum distance to report (in meters)** - If the distance is over this value (default 16m), it's likely inaccurate and not worth including in trilateration.
-* **Report early if beacon has moved more than this distance (in meters)** - If the device moves more than this distance, report immediately.
-* **Skip reporting if message age is less than this (in milliseconds)** - The logic is: if reported recently, check time elapsed and distance moved. If moved > "Report early" distance, report immediately. If time elapsed > "Skip reporting" time, report regardless of movement.
-*  **NOTE:**  Be certain to not filter out node IDs as inter-node communication is required for proper operation and can break items such as optimizers and Calibration in Companion.
+
+* **Include only sending these IDs to MQTT** — if set, ONLY matching ids are published (`include`). Example: `Apple:iphone10-6 Apple:iphone13-2`.
+* **Exclude sending these IDs to MQTT** — drop matching ids before publish (`exclude`). Example: `exp:20 Apple:iphone10-6`.
+* **Maximum distance to report (in meters)** — distances above this are dropped as likely-noise (`max_distance`, default `16.0`).
+* **Report early if beacon has moved more than this distance** — force-publish on a movement burst (`skip_distance`, default `0.5` m).
+* **Skip reporting if message age is less than this** (ms) — rate-limit per fingerprint (`skip_ms`, default `5000`). The logic is: if the device was reported recently, suppress until either the report-early distance is exceeded **or** `skip_ms` elapses.
+
+:::caution
+Do not filter out the per-node iBeacon ids. Nodes use one another's advertisements for inter-node distance measurements; suppressing them breaks Companion's optimizer and the Calibration helpers.
+:::
 
 ## Calibration
-These settings control how ESPresense interprets signal strength. See the full [Calibration](/guides/calibration) guide for detailed steps and examples, including how to use the RSSI adjustment for receiver to balance different antennas or dev boards.
 
-* RSSI expected from a 0dBm transmitter at 1 meter (NOT used for iBeacons or Eddystone) - Reference RSSI for non-calibrated devices.
-* RSSI adjustment for receiver (use only if you know this device has a weak antenna) - Per-node offset to align RSSI across different antennas or hardware.
-* Factor used to account for absorption, reflection, or diffraction - Adjusts for walls and other obstacles (Environmental Factor).
-* RSSI expected from this tx power at 1m (used for node iBeacon)
+These settings control how ESPresense converts RSSI to a distance estimate. See [Calibration](/guides/calibration) for the full procedure.
 
-For LED and GPIO sensor configuration (PIR motion, radar motion, switches, buttons), see the [Hardware](hardware) page.
+* **RSSI expected from a 0dBm transmitter at 1 meter** — reference RSSI for ad-hoc devices (`ref_rssi`, default `-65`). *Not* used for iBeacons or Eddystone — those carry their own calibrated RSSI in the advertisement.
+* **RSSI adjustment for receiver** — per-node offset to align antennas across boards (`rx_adj_rssi`, default `0`; `20` on ESP32-S3 by default to compensate for the on-chip antenna).
+* **Factor used to account for absorption, reflection, or diffraction** — environmental path-loss exponent (`absorption`, default `2.7`, range 1–5). Higher = more attenuation per meter.
+* **RSSI expected from this tx power at 1m** — calibration target for this node's own iBeacon broadcasts (`tx_ref_rssi`, default `-59`).
+
+For LED and GPIO sensor configuration (PIR motion, radar motion, switches, buttons), see [Hardware](/configuration/hardware).
+
+For the full topic list, command shapes, and over-the-air examples, see [MQTT](/configuration/mqtt).
+
+---
+
+*Last verified against firmware v4.0.6 (`main` @ d9a1765, 2026-05-10).*

--- a/src/content/docs/configuration/settings.md
+++ b/src/content/docs/configuration/settings.md
@@ -7,14 +7,14 @@ sidebar:
 
 <img src="/images/settings_screen.png" alt="Screenshot of ESP32 full settings interface" style="float:right;margin-left:20px;width:340px" />
 
-These settings are accessible from the **Settings** page in the device web UI. They can also be written live over [MQTT](/configuration/mqtt) — defaults and ranges for every option are listed in the [MQTT settings reference](/configuration/mqtt/#settings-reference).
+These settings are accessible from the **Settings** page in the device web UI. Most can also be written live over [MQTT](/configuration/mqtt) — defaults and ranges for every option are listed in the [MQTT settings reference](/configuration/mqtt/#settings-reference). The ones marked **boot only** below are read once at startup and have no `<key>/set` handler; change them in the captive portal / Settings page and reboot the node.
 
 ## Scanning
 
 * **Known BLE mac addresses** (no colons, space separated) — devices that use a random-but-static MAC. ESPresense publishes them with the stable id `known:{mac}`.
 * **Known BLE identity resolving keys** — 32-hex-character IRKs (space separated) that let ESPresense recognise Apple devices through their address rotation. See [Apple devices](/apple) for extraction tips.
-* **Forget beacon if not seen for (in milliseconds)** — drop idle fingerprints (`forget_ms`, default `150000` ms = 2.5 minutes).
-* **Maximum BLE fingerprints to track** — caps fingerprint memory at boot (`max_fingerprints`, default `100`; `200` on ESP32-S3/C3/C6).
+* **Forget beacon if not seen for (in milliseconds)** — drop idle fingerprints (`forget_ms`, default `150000` ms = 2.5 minutes). **Boot only.**
+* **Maximum BLE fingerprints to track** — caps fingerprint memory at boot (`max_fingerprints`, default `100`; `200` on ESP32-S3/C3/C6). **Boot only.**
 * **Allow active BLE connections to all devices** — `connect_all`. Bypasses the `query` allow-list and connects to everything. Expensive and rarely useful outside protocol debugging.
 
 ## Querying
@@ -22,16 +22,18 @@ These settings are accessible from the **Settings** page in the device web UI. T
 Most BLE devices give a usable id from passive advertisements alone, but some need an active GATT connection to identify themselves. **Query** opens that connection and reads the Room Assistant id, model, and name characteristics. When the device responds, ESPresense upgrades to the most-selective id available.
 
 * **Query device ids for characteristics** — id-prefix allow-list (`query`), e.g. `flora:` for Xiaomi Mi Flora plant sensors.
-* **Requery interval in seconds** — re-issue the active query every N seconds (`requery_ms`, default `300`, range 30–3600).
+* **Requery interval in seconds** — re-issue the active query every N seconds (`requery_ms`, default `300`, range 30–3600). **Boot only.**
 
 ## Counting
 
 A beta feature for devices that you can't fingerprint individually but where the *count* itself is useful — `exp:20` (COVID exposure apps), `apple:` (anonymous Apple devices), `Microsoft:cdp` (Microsoft devices). When set, auto-discovery adds a count sensor to your ESPresense node.
 
+Only `count_ids` is live-settable. The three hysteresis knobs (`count_enter`, `count_exit`, `count_ms`) are read once at boot.
+
 * **Include ID prefixes** (`count_ids`).
-* **Start counting devices less than distance** (m) — "enter" radius (`count_enter`, default `2.0`).
-* **Stop counting devices greater than distance** (m) — "leave" radius (`count_exit`, default `4.0`). Setting this above the enter radius creates a hysteresis band that prevents flapping.
-* **Include devices with age less than** (ms) — drop a device from the count if its last advertisement is older than this (`count_ms`, default `10000`).
+* **Start counting devices less than distance** (m) — "enter" radius (`count_enter`, default `2.0`). **Boot only.**
+* **Stop counting devices greater than distance** (m) — "leave" radius (`count_exit`, default `4.0`). Setting this above the enter radius creates a hysteresis band that prevents flapping. **Boot only.**
+* **Include devices with age less than** (ms) — drop a device from the count if its last advertisement is older than this (`count_ms`, default `10000`). **Boot only.**
 
 ## Filtering
 
@@ -50,7 +52,7 @@ Do not filter out the per-node iBeacon ids. Nodes use one another's advertisemen
 These settings control how ESPresense converts RSSI to a distance estimate. See [Calibration](/guides/calibration) for the full procedure.
 
 * **RSSI expected from a 0dBm transmitter at 1 meter** — reference RSSI for ad-hoc devices (`ref_rssi`, default `-65`). *Not* used for iBeacons or Eddystone — those carry their own calibrated RSSI in the advertisement.
-* **RSSI adjustment for receiver** — per-node offset to align antennas across boards (`rx_adj_rssi`, default `0`; `20` on ESP32-S3 by default to compensate for the on-chip antenna).
+* **RSSI adjustment for receiver** — per-node offset to align antennas across boards (`rx_adj_rssi`, default `0`; `20` on bare ESP32-S3 builds to compensate for the on-chip antenna). M5STICK and M5ATOM builds — even when they're S3-based — keep the default at `0` because those board defines are matched before `ESP32S3` in `include/defaults.h`.
 * **Factor used to account for absorption, reflection, or diffraction** — environmental path-loss exponent (`absorption`, default `2.7`, range 1–5). Higher = more attenuation per meter.
 * **RSSI expected from this tx power at 1m** — calibration target for this node's own iBeacon broadcasts (`tx_ref_rssi`, default `-59`).
 


### PR DESCRIPTION
## Summary

- Walk firmware source (`main` @ `d9a1765`, last release v4.0.6) and align the four configuration reference pages with what the code actually does — every option in `configuration/mqtt.md` / `settings.md` / `network.md` now matches a verified `HeadlessWiFiSettings.*` registration with its real default and range.
- New **REST API reference page** (`configuration/rest-api.md`) documents the previously-undocumented on-device HTTP surface: `/json`, `/json/devices`, `/json/configs`, `/restart`, `/ws`. Added to the *Node Configuration* sidebar.
- Every refreshed page carries a `Last verified against firmware vX.Y.Z (YYYY-MM-DD)` footer so readers (and the next refresh pass) can see freshness at a glance.

### Most user-visible additions to `mqtt.md`

- The **subscribe-side topics** (`espresense/rooms/*/+/set`, `espresense/rooms/<room>/+/set`, `espresense/settings/+/config`) — previously not documented anywhere on the site.
- Sensor / GPIO publish topics (`pir`, `radar`, `motion`, `switch_*`, `button_*`) and the LED `led_N/set` JSON shape — previously split between `hardware.md` and not-at-all.
- Missing options: `forget_ms`, `requery_ms`, `max_fingerprints`, `connect_all`, `count_enter`, `count_exit`, `count_ms`.
- The retained settings snapshot the node republishes on connect.
- Per-device topic shape (`espresense/devices/<id>/<room>` JSON), the topic Home Assistant's `mqtt_room` integration consumes.

### Out of scope for this PR

- Diagrams / screenshots (no UI changes here)
- Tutorial / how-to pages (covered by ESPA-39, ESPA-40)
- Contributor docs / Diataxis guidance (ESPA-42)
- The settings-snapshot publish list in firmware is incomplete (e.g. `skip_ms`, `connect_all`, the count knobs are not republished on connect) — filing a firmware child issue separately; docs describe the current behavior only.

## Test plan

- [x] `npm run build` is green; all 34 pages render including the new `/configuration/rest-api/`
- [x] No new broken cross-links (Astro build fails on bad slugs / dead links and didn't)
- [x] Every documented option grepped to a `HeadlessWiFiSettings.*` call or `Command()` branch in firmware source
- [ ] Spot-checked rendering on mobile width — please verify on the deploy preview
- [ ] Tech Lead / maintainer review of REST `/json/configs` shape and the BLE-protocol claims under `Querying` / `connect_all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new REST API documentation detailing available endpoints and usage.
  * Significantly expanded MQTT configuration guide with clearer topic structures, commands, and examples.
  * Enhanced network configuration documentation with explicit setup instructions and parameter details.
  * Improved settings documentation with better structure and cross-references.
  * Added firmware version verification notes across documentation pages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ESPresense/ESPresense.com/pull/317)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->