### PR TITLE
docs(nodes): link Amazon + manufacturer ref for M5 AtomS3 Lite + affiliate disclosure

### DIFF
--- a/src/content/docs/nodes.md
+++ b/src/content/docs/nodes.md
@@ -25,8 +25,7 @@ Some store links on this page (Amazon, AliExpress) are affiliate links. As an Am
 
 | Name               | Stores         | Notes |
 |:-------------------|:--------------:|-------|
-| M5 Atom S3 Lite    | [ali](https://s.click.aliexpress.com/e/_oFSxCND) | 8MB flash memory, built-in 3D antenna, IR emitter,  RGB LED, Button and GROVE interface [^cdc] |
-| M5 Atom S3         | [m5stack](https://docs.m5stack.com/en/core/AtomS3) [amz/us](https://amzn.to/4v3qPFm) | 0.85" IPS LCD, MPU6886 6-axis IMU, 8MB flash, built-in 3D antenna, USB-C [^cdc] |
+| M5 Atom S3 Lite    | [m5stack](https://docs.m5stack.com/en/core/AtomS3%20Lite) [ali](https://s.click.aliexpress.com/e/_oFSxCND) [amz/us](https://amzn.to/4v3qPFm) | 8MB flash memory, built-in 3D antenna, IR emitter, RGB LED, Button and GROVE interface [^cdc] |
 | M5 Atom S3U        | [ali](https://s.click.aliexpress.com/e/_c3bZmzLz) | USB-A w/ 8MB flash memory, built-in 3D antenna, IR emitter, PDM mic, RGB LED, Button and GROVE interface [^cdc] |
 | M5 Stamp S3        | [ali](https://s.click.aliexpress.com/e/_oB3a0Dv) | Stamp form factor w/ 8MB flash memory, built-in 3D antenna, and RGB LED [^cdc] |
 | Teyleten Robot | [ali](https://s.click.aliexpress.com/e/_c3JEwtzv) [amz/us](https://amzn.to/4jXMRUl) | 8MB flash and 2MB PSRAM dev board, sold as a 3-pack |

--- a/src/content/docs/nodes.md
+++ b/src/content/docs/nodes.md
@@ -9,6 +9,10 @@ The firmware is currently compatible with the original ESP32, ESP32-C3, and the 
 
 It is not compatible with the ESP32-S2 (doesn't have bluetooth), ESP32-C6 (too new no support in our dev environment), or ESP8266 (old, no bluetooth).
 
+:::note[Affiliate disclosure]
+Some store links on this page (Amazon, AliExpress) are affiliate links. As an Amazon Associate, ESPresense earns from qualifying purchases, at no extra cost to you. Affiliate revenue helps fund the project — see [Credits](/credits) for other ways to support.
+:::
+
 ## ESP32-C3
 
 | Name                | Stores       | Notes |
@@ -22,6 +26,7 @@ It is not compatible with the ESP32-S2 (doesn't have bluetooth), ESP32-C6 (too n
 | Name               | Stores         | Notes |
 |:-------------------|:--------------:|-------|
 | M5 Atom S3 Lite    | [ali](https://s.click.aliexpress.com/e/_oFSxCND) | 8MB flash memory, built-in 3D antenna, IR emitter,  RGB LED, Button and GROVE interface [^cdc] |
+| M5 Atom S3         | [m5stack](https://docs.m5stack.com/en/core/AtomS3) [amz/us](https://amzn.to/4v3qPFm) | 0.85" IPS LCD, MPU6886 6-axis IMU, 8MB flash, built-in 3D antenna, USB-C [^cdc] |
 | M5 Atom S3U        | [ali](https://s.click.aliexpress.com/e/_c3bZmzLz) | USB-A w/ 8MB flash memory, built-in 3D antenna, IR emitter, PDM mic, RGB LED, Button and GROVE interface [^cdc] |
 | M5 Stamp S3        | [ali](https://s.click.aliexpress.com/e/_oB3a0Dv) | Stamp form factor w/ 8MB flash memory, built-in 3D antenna, and RGB LED [^cdc] |
 | Teyleten Robot | [ali](https://s.click.aliexpress.com/e/_c3JEwtzv) [amz/us](https://amzn.to/4jXMRUl) | 8MB flash and 2MB PSRAM dev board, sold as a 3-pack |


### PR DESCRIPTION
## Summary

- DT clarified ([ESPA-111 thread](https://amzn.to/4v3qPFm)) that the supplied amzn.to link is the **AtomS3 Lite** (no LCD), which was already on the page with only an AliExpress link. Adds the manufacturer reference and the Amazon Associates link to that existing row instead of creating a duplicate.
- Manufacturer link points to [`docs.m5stack.com/en/core/AtomS3 Lite`](https://docs.m5stack.com/en/core/AtomS3%20Lite) (per `CONTRIBUTING-docs.md`: "link the manufacturer page first and the marketplace as a secondary 'where to buy'"). Shopify slugs for this product soft-404; docs is the durable manufacturer reference.
- Amazon link uses the foundation's existing `espresense-20` Associates tag.
- **Adds the Amazon Associates required disclosure** to the page. The site already has 15+ `amzn.to` affiliate links across `nodes.md` and `devices.md` but no disclosure, which is a gap in Amazon Associates Operating Agreement §5 ("clear and conspicuous" disclosure) and FTC guidance. Putting it on the page that actually has the links is the conspicuous spot.

## Source

CEO request via ESPA-111, with DT's product-ID correction comment.

## Test plan

- [ ] Render `/nodes` locally; confirm the new aside appears under the intro paragraph and the AtomS3 Lite row now lists three stores (m5stack docs, AliExpress, Amazon US).
- [ ] Confirm `https://amzn.to/4v3qPFm` resolves to the AtomS3 Lite listing on Amazon US.
- [ ] Confirm `https://docs.m5stack.com/en/core/AtomS3 Lite` renders the AtomS3 Lite spec page.
- [ ] Mobile-width render: aside collapses gracefully, table scrolls horizontally as expected.

## Notes for review

If the foundation prefers a different disclosure surface (site-wide footer, a dedicated `/affiliate-disclosure` page linked from every affiliate page, etc.), happy to refactor. Putting it inline on `nodes.md` was the smallest change that closes the compliance gap on the page being edited. A follow-up ESPA-112 will extend the chosen surface to `/devices`.