### PR TITLE
docs(devices): add affiliate disclosure aside

### DIFF
--- a/src/content/docs/devices.md
+++ b/src/content/docs/devices.md
@@ -4,6 +4,9 @@ sidebar:
   order: 3
 ---
 
+:::note[Affiliate disclosure]
+Some store links on this page (Amazon, AliExpress) are affiliate links. As an Amazon Associate, ESPresense earns from qualifying purchases, at no extra cost to you. Affiliate revenue helps fund the project — see [Credits](/credits) for other ways to support.
+:::
 
 ## Known working
 


### PR DESCRIPTION
## Summary

Companion to #328. Extends the same inline-per-page affiliate-disclosure pattern to `/devices`, which carries multiple `amzn.to` + `amzn.asia` Amazon Associates links and one `s.click.aliexpress.com` link but had no disclosure on the page.

- Adds a single `:::note[Affiliate disclosure]` aside under the frontmatter on `src/content/docs/devices.md`, matching the wording shipped to `/nodes` in #328.
- Surface choice — **inline-per-page** — was confirmed on ESPA-111 after the PR #328 review.
- Sanity-grepped the rest of the docs site (`amzn|amazon|s.click.aliexpress|aliexpress.com`): only `devices.md` and `nodes.md` carry affiliate links, so no additional pages need this treatment.

## Why

Amazon Associates Operating Agreement §5 and FTC guidance require a disclosure on each page that carries affiliate links. `/nodes` was brought into compliance in #328; this PR closes the gap on `/devices`.

## Test plan

- [ ] Astro/Starlight build succeeds without `:::note` parsing warnings
- [ ] Rendered page shows the aside between the title and the "Known working" table
- [ ] `/credits` link in the aside resolves