### PR TITLE
docs(credits): add Supporting the project section

### DIFF
--- a/src/content/docs/credits.md
+++ b/src/content/docs/credits.md
@@ -5,6 +5,22 @@ sidebar:
 ---
 
 
+## Supporting the project
+
+ESPresense is built and maintained by volunteers. Anything on this list helps — pick whichever fits.
+
+**Free things that help:**
+
+- Star the repos: [ESPresense/ESPresense](https://github.com/ESPresense/ESPresense) (firmware), [ESPresense/ESPresense-companion](https://github.com/ESPresense/ESPresense-companion) (daemon), and [ESPresense/ESPresense.com](https://github.com/ESPresense/ESPresense.com) (these docs).
+- File a clear bug report or share a working config — both make the project better for the next person.
+- Send a docs PR. Even a typo fix is welcome — see [`CONTRIBUTING-docs.md`](https://github.com/ESPresense/ESPresense.com/blob/main/CONTRIBUTING-docs.md).
+- Help someone in [Discussions](https://github.com/ESPresense/ESPresense/discussions) or on the issue tracker.
+
+**If you want to chip in money:**
+
+- Recurring or one-off donations: [GitHub Sponsors](https://github.com/sponsors/ESPresense), [Patreon](https://www.patreon.com/ESPresense), or [Ko-fi](https://ko-fi.com/ESPresense).
+- Buy hardware through the affiliate links on [/nodes](/nodes) and [/devices](/devices). As an Amazon Associate, ESPresense earns from qualifying purchases — at no extra cost to you.
+
 ## Fork of ESP32-mqtt-room
 
 ESPresense is a fork/rewrite of [ESP32-mqtt-room](https://jptrsn.github.io/ESP32-mqtt-room).


### PR DESCRIPTION
## Summary

Follow-up to #329, addressing DT's feedback that `/credits` "doesn't really have any details on supporting the project" — the affiliate-disclosure aside on `/nodes` and `/devices` links there "for other ways to support," but `/credits` was previously just a list of upstream libraries with no actual support paths.

Adds a **Supporting the project** section near the top that documents the channels that already exist:

- **Free things that help** — starring the repos, clear bug reports, docs PRs, helping in Discussions.
- **If you want to chip in money** — GitHub Sponsors / Patreon / Ko-fi (already configured in [`ESPresense/ESPresense/.github/FUNDING.yml`](https://github.com/ESPresense/ESPresense/blob/main/.github/FUNDING.yml)), plus the affiliate-link path on `/nodes` and `/devices`.

No invented donation channels — only what's already configured in the firmware repo's FUNDING.yml. No emoji, plain talk, matches the rest of the docs voice.

## Why

Makes the existing affiliate-disclosure asides honest: the "see Credits for other ways to support" sentence now points at a section that actually describes those other ways.

## Test plan

- [ ] Astro/Starlight build succeeds
- [ ] Rendered `/credits` page shows the new "Supporting the project" section at the top, above "Fork of ESP32-mqtt-room"
- [ ] All three sponsorship links resolve (GitHub Sponsors, Patreon, Ko-fi)
- [ ] All three repo links resolve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Supporting the project" section to credits documentation detailing volunteer maintenance practices and contribution methods available to users—including free options like community engagement, issue reporting, and documentation improvements, plus financial support channels through sponsorships and partnerships.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ESPresense/ESPresense.com/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->