### PR TITLE
Open external links in a new tab

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,13 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import rehypeExternalLinks from 'rehype-external-links';
 export default defineConfig({
   site: 'https://espresense.com',
+  markdown: {
+    rehypePlugins: [
+      [rehypeExternalLinks, { target: '_blank', rel: ['noopener', 'noreferrer'] }],
+    ],
+  },
   redirects: {
     '/beacons': '/devices',
     '/beacons/android': '/android',

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "astro": "^6.3.2",
         "fflate": "^0.7.3",
         "hono": "^4.12.18",
+        "rehype-external-links": "^3.0.0",
         "sharp": "^0.33.0"
       },
       "devDependencies": {
@@ -4145,6 +4146,18 @@
         "url": "https://github.com/sponsors/brc-dd"
       }
     },
+    "node_modules/is-absolute-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
@@ -6421,6 +6434,24 @@
       "license": "MIT",
       "dependencies": {
         "expressive-code": "^0.41.7"
+      }
+    },
+    "node_modules/rehype-external-links": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "is-absolute-url": "^4.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rehype-format": {

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
     "screenshots": "node scripts/capture-screenshots.js"
   },
   "dependencies": {
-    "astro": "^6.3.2",
     "@astrojs/starlight": ">=0.35.0",
-    "sharp": "^0.33.0",
+    "astro": "^6.3.2",
     "fflate": "^0.7.3",
-    "hono": "^4.12.18"
+    "hono": "^4.12.18",
+    "rehype-external-links": "^3.0.0",
+    "sharp": "^0.33.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251210.0",


### PR DESCRIPTION
## Summary
- Adds [rehype-external-links](https://github.com/rehypejs/rehype-external-links) to the markdown pipeline
- All external URLs across the docs now render with `target="_blank"` + `rel="noopener noreferrer"`
- Internal links (relative paths like `/firmware`, `/quick-start`) are unaffected

## Why
Store/affiliate links on `/nodes` and tutorial cross-references to GitHub discussions kept yanking readers off the docs without warning. Opening external links in a new tab is the convention most docs sites follow.

## Test plan
- [x] `npx astro build` clean — 36 pages
- [x] Local dev server: external links (Amazon, AliExpress, m5stack, github.com, home-assistant.io) get `target="_blank"`; internal links (`/firmware`, `/credits`) do not
- [x] Reviewer spot-check on Cloudflare preview

Made with [Orca](https://github.com/stablyai/orca) 🐋
