### PR TITLE
docs(mqtt): drop "default for Home Assistant" claim from broker intro

### DIFF
--- a/src/content/docs/configuration/mqtt.md
+++ b/src/content/docs/configuration/mqtt.md
@@ -7,7 +7,7 @@ sidebar:
 
 If you end up deploying a fleet of ESP32s in your home, it can quickly become painful to go to each device to update settings.
 
-You can use tools like [MQTT explorer](https://mqtt-explorer.com) or if you are using mosquitto (default for Home Assistant), the `mosquitto_sub` and `mosquitto_pub` tools to view and manage the settings.
+Any standard MQTT client works for inspecting and updating settings — [MQTT Explorer](https://mqtt-explorer.com) for a GUI, or the `mosquitto_sub` / `mosquitto_pub` CLI tools (they ship with the Mosquitto project but talk to any MQTT broker).
 
 
 ```bash


### PR DESCRIPTION
## Summary
The intro on `/configuration/mqtt` said Mosquitto is the default for Home Assistant — it isn't; HA supports any MQTT broker and Mosquitto is just one option (typically installed as an add-on). The `mosquitto_sub` / `mosquitto_pub` CLI tools also work against any MQTT broker, not just Mosquitto, so the conditional framing ("if you are using mosquitto…") is misleading.

## Diff
- Before: *You can use tools like MQTT explorer or if you are using mosquitto (default for Home Assistant), the `mosquitto_sub` and `mosquitto_pub` tools to view and manage the settings.*
- After: *Any standard MQTT client works for inspecting and updating settings — [MQTT Explorer](https://mqtt-explorer.com) for a GUI, or the `mosquitto_sub` / `mosquitto_pub` CLI tools (they ship with the Mosquitto project but talk to any MQTT broker).*

## Test plan
- [ ] Reviewer eyeballs `/configuration/mqtt` on the Cloudflare preview.

Made with [Orca](https://github.com/stablyai/orca) 🐋
