### PR TITLE
docs(quick-start): drop reader-facing "Last verified" footer

### DIFF
--- a/src/content/docs/quick-start.md
+++ b/src/content/docs/quick-start.md
@@ -170,6 +170,5 @@ Walk back. The sensor flips back to the room name.
 
 For everything else, the [Troubleshooting section](/troubleshooting/data-flow) and the [GitHub Discussions](https://github.com/ESPresense/ESPresense/discussions) are the places to look. Search before posting — most first-run problems have been answered before.
 
----
+<!-- Last verified against firmware v4.0.6 on 2026-05-10 with an M5 Atom S3 Lite, a Home Assistant 2026.4 install running the Mosquitto add-on, and an iPhone 15 enrolled via the UI flow. -->
 
-*Last verified against firmware v4.0.6 on 2026-05-10 with an M5 Atom S3 Lite, a Home Assistant 2026.4 install running the Mosquitto add-on, and an iPhone 15 enrolled via the UI flow.*


### PR DESCRIPTION
## Summary
Same cleanup we just applied to `/nodes` in #320 — move the *"Last verified against firmware v4.0.6 on 2026-05-10..."* italic footer into an HTML comment. Readers don't care about doc-audit metadata; the info still lives in the source for maintainers via `git blame` + comment.

## Diff
- Removes the visible italic footer at the bottom of `/quick-start`
- Removes the orphan `---` (`<hr>`) that was only there to set off the footer
- Adds `<!-- Last verified … -->` in the same place

Made with [Orca](https://github.com/stablyai/orca) 🐋
