### PR TITLE
Docs: lift boards canonical pin into permanent reference page

### DIFF
--- a/src/content/docs/nodes.md
+++ b/src/content/docs/nodes.md
@@ -35,7 +35,7 @@ Pick a chip first, then a board within it.
 | ESP32-S2 | no | No Bluetooth radio |
 | ESP8266 | no | No Bluetooth radio |
 
-## Community-tested (branded)
+## Community-tested (tier 2)
 
 Branded boards we actively point new users at. All flash with the [browser installer](/firmware). [^cdc]
 

--- a/src/content/docs/nodes.md
+++ b/src/content/docs/nodes.md
@@ -7,9 +7,9 @@ sidebar:
 
 <!-- Last verified against firmware v4.0.6 on 2026-05-11. -->
 
-Community-voiced board data and quotes are lifted from the canonical pin: [discussion #2334 &mdash; Boards: what works, what's flaky, what to avoid](https://github.com/ESPresense/ESPresense/discussions/2334). If a board you've run isn't listed, comment on that thread and we'll fold it in.
+Community-voiced board data and quotes are lifted from the canonical pin: [discussion #2334 — Boards: what works, what's flaky, what to avoid](https://github.com/ESPresense/ESPresense/discussions/2334). If a board you've run isn't listed, comment on that thread and we'll fold it in.
 
-## First-time buyer (tier&nbsp;1)
+## First-time buyer (tier 1)
 
 If you've never deployed ESPresense before, buy one of these. Both are branded, enclosed (or stamp-form, not a bare clone PCB), ship with a 3D antenna, and the [browser installer](/firmware) picks the right firmware flavour automatically.
 
@@ -17,10 +17,10 @@ If you've never deployed ESPresense before, buy one of these. Both are branded, 
 Some store links on this page (Amazon, AliExpress) are affiliate links. As an Amazon Associate, ESPresense earns from qualifying purchases, at no extra cost to you. Affiliate revenue helps fund the project — see [Credits](/credits) for other ways to support.
 :::
 
-| Board | Chip | Why it's tier&nbsp;1 | Stores |
+| Board | Chip | Why it's tier 1 | Stores |
 |:------|:-----|:--------------------|:-------|
-| **M5 Atom S3 Lite** | ESP32-S3 | First-timer pick: ~$15, enclosed, USB-C, status LED, 8&nbsp;MB flash, noticeably better BT range than original ESP32 [^cdc] | [m5stack](https://docs.m5stack.com/en/core/AtomS3%20Lite) [ali](https://s.click.aliexpress.com/e/_oFSxCND) [amz/us](https://amzn.to/4v3qPFm) |
-| **M5 Stamp C3 Mate** | ESP32-C3 | Cost-conscious pick: stamp form, RISC-V, runs cool, 4&nbsp;MB flash, 3D antenna, RGB LED | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-mate-with-pin-headers) [ali](https://s.click.aliexpress.com/e/_omweFp9) |
+| **M5 Atom S3 Lite** | ESP32-S3 | First-timer pick: ~$15, enclosed, USB-C, status LED, 8 MB flash, noticeably better BT range than original ESP32 [^cdc] | [m5stack](https://docs.m5stack.com/en/core/AtomS3%20Lite) [ali](https://s.click.aliexpress.com/e/_oFSxCND) [amz/us](https://amzn.to/4v3qPFm) |
+| **M5 Stamp C3 Mate** | ESP32-C3 | Cost-conscious pick: stamp form, RISC-V, runs cool, 4 MB flash, 3D antenna, RGB LED | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-mate-with-pin-headers) [ali](https://s.click.aliexpress.com/e/_omweFp9) |
 
 ## Chip families
 
@@ -28,8 +28,8 @@ Pick a chip first, then a board within it.
 
 | Chip | Supported | Notes |
 |:-----|:----------|:------|
-| ESP32-S3 | yes &mdash; recommended for new deployments | 8&nbsp;MB flash typical, BT 5.0 LE coded PHY, USB-CDC |
-| ESP32-C3 | yes &mdash; recommended for cost-sensitive deployments | RISC-V, 4&nbsp;MB flash typical |
+| ESP32-S3 | yes — recommended for new deployments | 8 MB flash typical, BT 5.0 LE coded PHY, USB-CDC |
+| ESP32-C3 | yes — recommended for cost-sensitive deployments | RISC-V, 4 MB flash typical |
 | ESP32-C6 | yes | Newer RISC-V part with BT 5.3; firmware build available |
 | Original ESP32 | yes | Still fully supported; stick to branded boards |
 | ESP32-S2 | no | No Bluetooth radio |
@@ -43,18 +43,18 @@ Branded boards we actively point new users at. The [browser installer](/firmware
 
 | Board | Stores | Notes |
 |:------|:-------|:------|
-| M5 Atom S3 Lite | [m5stack](https://docs.m5stack.com/en/core/AtomS3%20Lite) [ali](https://s.click.aliexpress.com/e/_oFSxCND) [amz/us](https://amzn.to/4v3qPFm) | Enclosed, USB-C. 8&nbsp;MB flash, 3D antenna, IR emitter, RGB LED, button, GROVE [^cdc] |
-| M5 Atom S3U | [ali](https://s.click.aliexpress.com/e/_c3bZmzLz) | Enclosed, USB-A. 8&nbsp;MB flash, 3D antenna, IR emitter, PDM mic, RGB LED, button, GROVE [^cdc] |
-| M5 Stamp S3 | [ali](https://s.click.aliexpress.com/e/_oB3a0Dv) | Stamp form. 8&nbsp;MB flash, 3D antenna, RGB LED [^cdc] |
-| Teyleten Robot S3 | [ali](https://s.click.aliexpress.com/e/_c3JEwtzv) [amz/us](https://amzn.to/4jXMRUl) | Dev board. 8&nbsp;MB flash + 2&nbsp;MB PSRAM. Sold as a 3-pack [^cdc] |
+| M5 Atom S3 Lite | [m5stack](https://docs.m5stack.com/en/core/AtomS3%20Lite) [ali](https://s.click.aliexpress.com/e/_oFSxCND) [amz/us](https://amzn.to/4v3qPFm) | Enclosed, USB-C. 8 MB flash, 3D antenna, IR emitter, RGB LED, button, GROVE [^cdc] |
+| M5 Atom S3U | [ali](https://s.click.aliexpress.com/e/_c3bZmzLz) | Enclosed, USB-A. 8 MB flash, 3D antenna, IR emitter, PDM mic, RGB LED, button, GROVE [^cdc] |
+| M5 Stamp S3 | [ali](https://s.click.aliexpress.com/e/_oB3a0Dv) | Stamp form. 8 MB flash, 3D antenna, RGB LED [^cdc] |
+| Teyleten Robot S3 | [ali](https://s.click.aliexpress.com/e/_c3JEwtzv) [amz/us](https://amzn.to/4jXMRUl) | Dev board. 8 MB flash + 2 MB PSRAM. Sold as a 3-pack [^cdc] |
 
 ### ESP32-C3
 
 | Board | Stores | Notes |
 |:------|:-------|:------|
-| M5 Stamp C3 Mate | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-mate-with-pin-headers) [ali](https://s.click.aliexpress.com/e/_omweFp9) | Stamp form. 4&nbsp;MB flash, 3D antenna, RGB LED, button |
-| M5 Stamp C3U Mate | [ali](https://s.click.aliexpress.com/e/_onkgbFp) | Stamp form, USB-A. 4&nbsp;MB flash, 3D antenna, RGB LED, button [^cdc] |
-| ESP32-C3-DevKitM-1U | [ali](https://s.click.aliexpress.com/e/_c3bVwFQb) [amz/us](https://amzn.to/41WQXFa) | Espressif's dev board with ESP32-C3-MINI-1U module and U.FL connector. 4&nbsp;MB flash, 160&nbsp;MHz |
+| M5 Stamp C3 Mate | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-mate-with-pin-headers) [ali](https://s.click.aliexpress.com/e/_omweFp9) | Stamp form. 4 MB flash, 3D antenna, RGB LED, button |
+| M5 Stamp C3U Mate | [ali](https://s.click.aliexpress.com/e/_onkgbFp) | Stamp form, USB-A. 4 MB flash, 3D antenna, RGB LED, button [^cdc] |
+| ESP32-C3-DevKitM-1U | [ali](https://s.click.aliexpress.com/e/_c3bVwFQb) [amz/us](https://amzn.to/41WQXFa) | Espressif's dev board with ESP32-C3-MINI-1U module and U.FL connector. 4 MB flash, 160 MHz |
 
 ### Original ESP32
 
@@ -66,7 +66,7 @@ Branded boards we actively point new users at. The [browser installer](/firmware
 
 ## Works, with caveats
 
-These boards run ESPresense, but quality and RF behaviour vary. Use one you already own rather than buying a new one. **If a "with caveats" board misbehaves, reproduce on a tier&#8209;1 board before opening a firmware issue** &mdash; RF problems on a marginal clone look identical to firmware bugs and burn a lot of triage time.
+These boards run ESPresense, but antenna and module QC vary — RSSI from one of these often won't agree with a branded board at the same distance, which makes fleet calibration harder and is a real problem for Companion's room solver. Use one you already own rather than buying a new one. **If a "with caveats" board misbehaves, reproduce on a tier-1 board before opening a firmware issue** — RF problems on a marginal clone look identical to firmware bugs and burn a lot of triage time.
 
 | Board | Caveat | Source |
 |:------|:-------|:-------|
@@ -80,19 +80,19 @@ These boards run ESPresense, but quality and RF behaviour vary. Use one you alre
 
 Each of these comes up often enough that it's worth saying plainly:
 
-- **Unbranded "ESP32 dev board" listings (Amazon / AliExpress).** Cheap and *usually* fine, but WiFi/BLE quality varies wildly and the failure is silent &mdash; the board flashes, joins WiFi, reports to MQTT, but RSSI is erratic and you can't tell whether tracking problems are firmware, calibration or a bad RF front-end. @maxi1134 reports a 40-50% WiFi-retry rate on generic ESP32 dev boards ([#1364][1364], summarised in [#2334][p]). For your first node, spend the extra few dollars on a branded board.
+- **Unbranded "ESP32 dev board" listings (Amazon / AliExpress).** ESPresense uses RSSI as its primary input — every distance estimate and every Companion room solve assumes the fleet's readings agree with each other. Unbranded clones don't have consistent antenna designs even within a single product listing; two boards from the same batch routinely differ by several dB at the same distance, which translates to feet of error in the Companion floor plan. None of that matters for sensor/relay/presence projects like ESPHome, which is why *"these same cheap boards never drop with ESPHome"* is a common (and accurate, but irrelevant) objection — ESPHome isn't doing RSSI distance estimation across a calibrated fleet. The failure mode here is also silent: the board flashes, joins WiFi, reports to MQTT, but its RSSI numbers don't line up with the rest of the fleet and you can't tell whether bad tracking is firmware, calibration, or a bad RF front-end. @maxi1134 separately reports a 40-50% WiFi-retry rate on generic ESP32 dev boards ([#1364][1364], summarised in [#2334][p]). For any node you intend to calibrate against the fleet — and especially for Companion — spend the extra few dollars on a branded board.
 - **ESP32-CAM.** Not officially supported. Camera owns most of the GPIOs, tighter RAM, no maintained firmware variant. One community member keeps a fork working with source-side modifications ([#1347][1347]); we don't build for it.
-- **ESP32-S2 / ESP8266.** No Bluetooth radio &mdash; physically can't run ESPresense.
+- **ESP32-S2 / ESP8266.** No Bluetooth radio — physically can't run ESPresense.
 - **NSPanel as a base station.** Open question. The chip is an ESP32, but no one has reported flashing ESPresense over the stock NSPanel firmware and getting both the touch UI and BT scanning working ([#1335][1335]).
-- **GL-S10 Bluetooth IoT Gateway.** Not an ESP32 &mdash; MediaTek MT7621 with a separate BLE module &mdash; so the ESPresense firmware doesn't apply ([#1263][1263]).
+- **GL-S10 Bluetooth IoT Gateway.** Not an ESP32 — MediaTek MT7621 with a separate BLE module — so the ESPresense firmware doesn't apply ([#1263][1263]).
 
 ## Power and cabling
 
 ### USB-C chargers
 
-* [20W USB-C Wall Charger](https://amzn.to/4kXGphK) &mdash; small fast charger with foldable plug
+* [20W USB-C Wall Charger](https://amzn.to/4kXGphK) — small fast charger with foldable plug
 * [20W USB-C Wall Charger (3-pack)](https://amzn.to/4hFLcBz)
-* [20W USB-C Charger (AliExpress)](https://s.click.aliexpress.com/e/_c4Myg1Bl) &mdash; PD/QC 3.0
+* [20W USB-C Charger (AliExpress)](https://s.click.aliexpress.com/e/_c4Myg1Bl) — PD/QC 3.0
 
 ### USB-C to C cables
 
@@ -101,7 +101,7 @@ Each of these comes up often enough that it's worth saying plainly:
 
 ### USB-A chargers
 
-* [Dual USB-A 3-pack](https://amzn.to/4iA0EAq) &mdash; compact cube design
+* [Dual USB-A 3-pack](https://amzn.to/4iA0EAq) — compact cube design
 
 ### USB-A to C cables
 
@@ -116,9 +116,9 @@ Each of these comes up often enough that it's worth saying plainly:
 
 ## See also
 
-* [Canonical pin #2334][p] &mdash; community discussion, raw quotes, source threads
-* [Install Firmware](/firmware) &mdash; browser-based installer
-* [Discord](https://discord.gg/jbqmn7V6n6) &mdash; faster human turnaround on board questions
+* [Canonical pin #2334][p] — community discussion, raw quotes, source threads
+* [Install Firmware](/firmware) — browser-based installer
+* [Discord](https://discord.gg/jbqmn7V6n6) — faster human turnaround on board questions
 
 ## Footnotes
 

--- a/src/content/docs/nodes.md
+++ b/src/content/docs/nodes.md
@@ -89,7 +89,7 @@ Each of these comes up often enough that it's worth saying plainly:
 ### USB-C chargers
 
 * [20W USB-C Wall Charger](https://amzn.to/4kXGphK) &mdash; small fast charger with foldable plug
-* [20W USB-C Wall Charger (3 pack)](https://amzn.to/4hFLcBz)
+* [20W USB-C Wall Charger (3-pack)](https://amzn.to/4hFLcBz)
 * [20W USB-C Charger (AliExpress)](https://s.click.aliexpress.com/e/_c4Myg1Bl) &mdash; PD/QC 3.0
 
 ### USB-C to C cables
@@ -99,14 +99,14 @@ Each of these comes up often enough that it's worth saying plainly:
 
 ### USB-A chargers
 
-* [Dual USB-A 3 pack](https://amzn.to/4iA0EAq) &mdash; compact cube design
+* [Dual USB-A 3-pack](https://amzn.to/4iA0EAq) &mdash; compact cube design
 
 ### USB-A to C cables
 
-* [16 ft, 2 pack](https://amzn.to/3zzTTXW)
-* [1 ft, 6 pack](https://amzn.to/3kyD8Is)
-* [Straight adapter 4 pack](https://amzn.to/4hNrh3O)
-* [Right-angle adapter 4 pack](https://amzn.to/4bWWH6o)
+* [16 ft, 2-pack](https://amzn.to/3zzTTXW)
+* [1 ft, 6-pack](https://amzn.to/3kyD8Is)
+* [Straight adapter 4-pack](https://amzn.to/4hNrh3O)
+* [Right-angle adapter 4-pack](https://amzn.to/4bWWH6o)
 
 ### USB-A to Micro-B cables
 

--- a/src/content/docs/nodes.md
+++ b/src/content/docs/nodes.md
@@ -20,7 +20,7 @@ Some store links on this page (Amazon, AliExpress) are affiliate links. As an Am
 | Board | Chip | Why it's tier 1 | Stores |
 |:------|:-----|:--------------------|:-------|
 | **M5 Atom S3 Lite** | ESP32-S3 | First-timer pick: ~$15, enclosed, USB-C, status LED, 8 MB flash, noticeably better BT range than original ESP32 [^cdc] | [m5stack](https://docs.m5stack.com/en/core/AtomS3%20Lite) [ali](https://s.click.aliexpress.com/e/_oFSxCND) [amz/us](https://amzn.to/4v3qPFm) |
-| **M5 Stamp C3 Mate** | ESP32-C3 | Cost-conscious pick: stamp form, RISC-V, runs cool, 4 MB flash, 3D antenna, RGB LED | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-mate-with-pin-headers) [ali](https://s.click.aliexpress.com/e/_omweFp9) |
+| **M5 Stamp C3 Mate** | ESP32-C3 | Cost-conscious pick: stamp form, RISC-V, runs cool, 4 MB flash, 3D antenna, RGB LED | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-mate-with-pin-headers) [ali](https://s.click.aliexpress.com/e/_omweFp9) [amz/us](https://amzn.to/4tVkzP4) |
 
 ## Chip families
 
@@ -52,7 +52,7 @@ Branded boards we actively point new users at. The [browser installer](/firmware
 
 | Board | Stores | Notes |
 |:------|:-------|:------|
-| M5 Stamp C3 Mate | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-mate-with-pin-headers) [ali](https://s.click.aliexpress.com/e/_omweFp9) | Stamp form. 4 MB flash, 3D antenna, RGB LED, button |
+| M5 Stamp C3 Mate | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-mate-with-pin-headers) [ali](https://s.click.aliexpress.com/e/_omweFp9) [amz/us](https://amzn.to/4tVkzP4) | Stamp form. 4 MB flash, 3D antenna, RGB LED, button |
 | M5 Stamp C3U Mate | [ali](https://s.click.aliexpress.com/e/_onkgbFp) | Stamp form, USB-A. 4 MB flash, 3D antenna, RGB LED, button [^cdc] |
 | ESP32-C3-DevKitM-1U | [ali](https://s.click.aliexpress.com/e/_c3bVwFQb) [amz/us](https://amzn.to/41WQXFa) | Espressif's dev board with ESP32-C3-MINI-1U module and U.FL connector. 4 MB flash, 160 MHz |
 

--- a/src/content/docs/nodes.md
+++ b/src/content/docs/nodes.md
@@ -9,19 +9,6 @@ sidebar:
 
 Community-voiced board data and quotes are lifted from the canonical pin: [discussion #2334 — Boards: what works, what's flaky, what to avoid](https://github.com/ESPresense/ESPresense/discussions/2334). If a board you've run isn't listed, comment on that thread and we'll fold it in.
 
-## First-time buyer (tier 1)
-
-If you've never deployed ESPresense before, buy one of these. Both are branded, enclosed (or stamp-form, not a bare clone PCB), and ship with a 3D antenna. Flash them with the [browser installer](/firmware) and you're done.
-
-:::note[Affiliate disclosure]
-Some store links on this page (Amazon, AliExpress) are affiliate links. As an Amazon Associate, ESPresense earns from qualifying purchases, at no extra cost to you. Affiliate revenue helps fund the project — see [Credits](/credits) for other ways to support.
-:::
-
-| Board | Chip | Why it's tier 1 | Stores |
-|:------|:-----|:--------------------|:-------|
-| **M5 Atom S3 Lite** | ESP32-S3 | First-timer pick: ~$15, enclosed, USB-C, status LED, 8 MB flash, noticeably better BT range than original ESP32 [^cdc] | [m5stack](https://docs.m5stack.com/en/core/AtomS3%20Lite) [ali](https://s.click.aliexpress.com/e/_oFSxCND) [amz/us](https://amzn.to/4v3qPFm) |
-| **M5 Stamp C3 Mate** | ESP32-C3 | Cost-conscious pick: stamp form, RISC-V, runs cool, 4 MB flash, 3D antenna, RGB LED | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-5pcs) [ali](https://s.click.aliexpress.com/e/_omweFp9) [amz/us](https://amzn.to/4tVkzP4) |
-
 ## Chip families
 
 Pick a chip first, then a board within it.
@@ -35,15 +22,21 @@ Pick a chip first, then a board within it.
 | ESP32-S2 | no | No Bluetooth radio |
 | ESP8266 | no | No Bluetooth radio |
 
-## Community-tested (tier 2)
+## Recommended boards
 
-Branded boards we actively point new users at. All flash with the [browser installer](/firmware). [^cdc]
+**The boards in bold are the picks if you don't want to think about it** — M5 Atom S3 Lite as the default, M5 Stamp C3 Mate as a cost-conscious alternative.
+
+All branded boards listed here flash with the [browser installer](/firmware). [^cdc]
+
+:::note[Affiliate disclosure]
+Some store links on this page (Amazon, AliExpress) are affiliate links. As an Amazon Associate, ESPresense earns from qualifying purchases, at no extra cost to you. Affiliate revenue helps fund the project — see [Credits](/credits) for other ways to support.
+:::
 
 ### ESP32-S3
 
 | Board | Stores | Notes |
 |:------|:-------|:------|
-| M5 Atom S3 Lite | [m5stack](https://docs.m5stack.com/en/core/AtomS3%20Lite) [ali](https://s.click.aliexpress.com/e/_oFSxCND) [amz/us](https://amzn.to/4v3qPFm) | Enclosed, USB-C. 8 MB flash, 3D antenna, IR emitter, RGB LED, button, GROVE [^cdc] |
+| **M5 Atom S3 Lite** | [m5stack](https://docs.m5stack.com/en/core/AtomS3%20Lite) [ali](https://s.click.aliexpress.com/e/_oFSxCND) [amz/us](https://amzn.to/4v3qPFm) | Enclosed, USB-C. 8 MB flash, 3D antenna, IR emitter, RGB LED, button, GROVE [^cdc] |
 | M5 Atom S3U | [ali](https://s.click.aliexpress.com/e/_c3bZmzLz) [amz/us](https://amzn.to/4uZJFgE) | Enclosed, USB-A. 8 MB flash, 3D antenna, IR emitter, PDM mic, RGB LED, button, GROVE [^cdc] |
 | M5 Stamp S3 | [ali](https://s.click.aliexpress.com/e/_oB3a0Dv) | Stamp form. 8 MB flash, 3D antenna, RGB LED [^cdc] |
 | Teyleten Robot S3 | [ali](https://s.click.aliexpress.com/e/_c3JEwtzv) [amz/us](https://amzn.to/4jXMRUl) | Dev board. 8 MB flash + 2 MB PSRAM. Sold as a 3-pack [^cdc] |
@@ -52,7 +45,7 @@ Branded boards we actively point new users at. All flash with the [browser insta
 
 | Board | Stores | Notes |
 |:------|:-------|:------|
-| M5 Stamp C3 Mate | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-5pcs) [ali](https://s.click.aliexpress.com/e/_omweFp9) [amz/us](https://amzn.to/4tVkzP4) | Stamp form. 4 MB flash, 3D antenna, RGB LED, button |
+| **M5 Stamp C3 Mate** | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-5pcs) [ali](https://s.click.aliexpress.com/e/_omweFp9) [amz/us](https://amzn.to/4tVkzP4) | Stamp form. 4 MB flash, 3D antenna, RGB LED, button |
 | M5 Stamp C3U Mate | [ali](https://s.click.aliexpress.com/e/_onkgbFp) | Stamp form, USB-A. 4 MB flash, 3D antenna, RGB LED, button [^cdc] |
 | ESP32-C3-DevKitM-1U | [ali](https://s.click.aliexpress.com/e/_c3bVwFQb) [amz/us](https://amzn.to/41WQXFa) | Espressif's dev board with ESP32-C3-MINI-1U module and U.FL connector. 4 MB flash, 160 MHz |
 

--- a/src/content/docs/nodes.md
+++ b/src/content/docs/nodes.md
@@ -44,7 +44,7 @@ Branded boards we actively point new users at. The [browser installer](/firmware
 | Board | Stores | Notes |
 |:------|:-------|:------|
 | M5 Atom S3 Lite | [m5stack](https://docs.m5stack.com/en/core/AtomS3%20Lite) [ali](https://s.click.aliexpress.com/e/_oFSxCND) [amz/us](https://amzn.to/4v3qPFm) | Enclosed, USB-C. 8 MB flash, 3D antenna, IR emitter, RGB LED, button, GROVE [^cdc] |
-| M5 Atom S3U | [ali](https://s.click.aliexpress.com/e/_c3bZmzLz) | Enclosed, USB-A. 8 MB flash, 3D antenna, IR emitter, PDM mic, RGB LED, button, GROVE [^cdc] |
+| M5 Atom S3U | [ali](https://s.click.aliexpress.com/e/_c3bZmzLz) [amz/us](https://amzn.to/4uZJFgE) | Enclosed, USB-A. 8 MB flash, 3D antenna, IR emitter, PDM mic, RGB LED, button, GROVE [^cdc] |
 | M5 Stamp S3 | [ali](https://s.click.aliexpress.com/e/_oB3a0Dv) | Stamp form. 8 MB flash, 3D antenna, RGB LED [^cdc] |
 | Teyleten Robot S3 | [ali](https://s.click.aliexpress.com/e/_c3JEwtzv) [amz/us](https://amzn.to/4jXMRUl) | Dev board. 8 MB flash + 2 MB PSRAM. Sold as a 3-pack [^cdc] |
 

--- a/src/content/docs/nodes.md
+++ b/src/content/docs/nodes.md
@@ -30,7 +30,7 @@ Pick a chip first, then a board within it.
 |:-----|:----------|:------|
 | ESP32-S3 | yes — recommended for new deployments | 8 MB flash typical, BT 5.0 LE coded PHY, USB-CDC |
 | ESP32-C3 | yes — recommended for cost-sensitive deployments | RISC-V, 4 MB flash typical |
-| ESP32-C6 | yes | Newer RISC-V part with BT 5.3; firmware build available |
+| ESP32-C6 | yes — bleeding edge | Newer RISC-V part with BT 5.3; firmware build available |
 | Original ESP32 | yes, for now | Older silicon with less CPU and RAM than the S3/C3/C6 parts. Still supported, but expect it to age out of new firmware features eventually — prefer a newer chip for new deployments. |
 | ESP32-S2 | no | No Bluetooth radio |
 | ESP8266 | no | No Bluetooth radio |

--- a/src/content/docs/nodes.md
+++ b/src/content/docs/nodes.md
@@ -71,7 +71,7 @@ These boards run ESPresense, but antenna and module QC vary — RSSI from one of
 | Board | Caveat | Source |
 |:------|:-------|:-------|
 | AZDelivery ESP32 NodeMCU (WROOM-32 module on a generic dev board) | Works but no brand QC | [#2334][p] / [#1567][1567], [#1577][1577] |
-| Generic D1 Mini ESP32 (Micro-B and USB-C) | Multiple users report working in practice; same no-brand &rarr; no-QC caveat on the RF front-end | [#2334][p] / [#162][162] |
+| Generic D1 Mini ESP32 (Micro-B and USB-C) | Multiple users report working in practice; same no-brand → no-QC caveat on the RF front-end | [#2334][p] / [#162][162] |
 | LOLIN D32 ESP32 | Works; unbranded RF caveat | [#2334][p] |
 | M5StickC Plus | Built-in battery is a liability for a fixed-in-place node | [#2334][p] |
 | SEEEDSTUDIO XIAO ESP32-C3 | Runs on the `esp32C3` flavour. One report of a board overheating ([#1364][1364]); use a known-good USB-C cable and a real power supply | [#2334][p] / [#1364][1364] |

--- a/src/content/docs/nodes.md
+++ b/src/content/docs/nodes.md
@@ -31,7 +31,7 @@ Pick a chip first, then a board within it.
 | ESP32-S3 | yes — recommended for new deployments | 8 MB flash typical, BT 5.0 LE coded PHY, USB-CDC |
 | ESP32-C3 | yes — recommended for cost-sensitive deployments | RISC-V, 4 MB flash typical |
 | ESP32-C6 | yes | Newer RISC-V part with BT 5.3; firmware build available |
-| Original ESP32 | yes | Still fully supported; stick to branded boards |
+| Original ESP32 | yes, for now | Older silicon with less CPU and RAM than the S3/C3/C6 parts. Still supported, but expect it to age out of new firmware features eventually — prefer a newer chip for new deployments. |
 | ESP32-S2 | no | No Bluetooth radio |
 | ESP8266 | no | No Bluetooth radio |
 

--- a/src/content/docs/nodes.md
+++ b/src/content/docs/nodes.md
@@ -5,7 +5,9 @@ sidebar:
   order: 4
 ---
 
-> **Last verified against firmware v4.0.6** &mdash; 2026-05-11. Community-voiced board data and quotes are lifted from the canonical pin: [discussion #2334 &mdash; Boards: what works, what's flaky, what to avoid](https://github.com/ESPresense/ESPresense/discussions/2334). If a board you've run isn't listed, comment on that thread and we'll fold it in.
+<!-- Last verified against firmware v4.0.6 on 2026-05-11. -->
+
+Community-voiced board data and quotes are lifted from the canonical pin: [discussion #2334 &mdash; Boards: what works, what's flaky, what to avoid](https://github.com/ESPresense/ESPresense/discussions/2334). If a board you've run isn't listed, comment on that thread and we'll fold it in.
 
 ## First-time buyer (tier&nbsp;1)
 

--- a/src/content/docs/nodes.md
+++ b/src/content/docs/nodes.md
@@ -1,80 +1,132 @@
 ---
 title: Nodes
+description: Reference list of ESP32 boards that run ESPresense, organised by tier from first-time-buyer pick to steer-away.
 sidebar:
   order: 4
 ---
 
+> **Last verified against firmware v4.0.6** &mdash; 2026-05-11. Community-voiced board data and quotes are lifted from the canonical pin: [discussion #2334 &mdash; Boards: what works, what's flaky, what to avoid](https://github.com/ESPresense/ESPresense/discussions/2334). If a board you've run isn't listed, comment on that thread and we'll fold it in.
 
-The firmware is currently compatible with the original ESP32, ESP32-C3, and the ESP32-S3.  Generally C3 or S3 is recommended for new deployments.  The C3 is nice and cheap and the RISC-V is fast!  The S3 has better bluetooth range but is a bit more pricey.
+## First-time buyer (tier&nbsp;1)
 
-It is not compatible with the ESP32-S2 (doesn't have bluetooth), ESP32-C6 (too new no support in our dev environment), or ESP8266 (old, no bluetooth).
+If you've never deployed ESPresense before, buy one of these. Both are branded, enclosed (or stamp-form, not a bare clone PCB), ship with a 3D antenna, and the [browser installer](/firmware) picks the right firmware flavour automatically.
 
 :::note[Affiliate disclosure]
 Some store links on this page (Amazon, AliExpress) are affiliate links. As an Amazon Associate, ESPresense earns from qualifying purchases, at no extra cost to you. Affiliate revenue helps fund the project — see [Credits](/credits) for other ways to support.
 :::
 
-## ESP32-C3
+| Board | Chip | Why it's tier&nbsp;1 | Stores |
+|:------|:-----|:--------------------|:-------|
+| **M5 Atom S3 Lite** | ESP32-S3 | First-timer pick: ~$15, enclosed, USB-C, status LED, 8&nbsp;MB flash, noticeably better BT range than original ESP32 [^cdc] | [m5stack](https://docs.m5stack.com/en/core/AtomS3%20Lite) [ali](https://s.click.aliexpress.com/e/_oFSxCND) [amz/us](https://amzn.to/4v3qPFm) |
+| **M5 Stamp C3 Mate** | ESP32-C3 | Cost-conscious pick: stamp form, RISC-V, runs cool, 4&nbsp;MB flash, 3D antenna, RGB LED | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-mate-with-pin-headers) [ali](https://s.click.aliexpress.com/e/_omweFp9) |
 
-| Name                | Stores       | Notes |
-|:--------------------|:------------:|-------|
-| M5 Stamp C3 Mate    | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-mate-with-pin-headers) [ali](https://s.click.aliexpress.com/e/_omweFp9) | Stamp form factor w/ 4MB flash memory, built-in 3D antenna, RGB LED and button |
-| M5 Stamp C3U Mate   | [ali](https://s.click.aliexpress.com/e/_onkgbFp) | Stamp form factor w/ 4MB flash memory, built-in 3D antenna, RGB LED and button [^cdc] |
-| ESP32-C3-DevKitM-1U | [ali](https://s.click.aliexpress.com/e/_c3bVwFQb) [amz/us](https://amzn.to/41WQXFa) | Espressif's official development board with ESP32-C3-MINI-1U module, 4MB flash, 160MHz CPU |
+## Chip families
 
-## ESP32-S3
+Pick a chip first, then a board within it.
 
-| Name               | Stores         | Notes |
-|:-------------------|:--------------:|-------|
-| M5 Atom S3 Lite    | [m5stack](https://docs.m5stack.com/en/core/AtomS3%20Lite) [ali](https://s.click.aliexpress.com/e/_oFSxCND) [amz/us](https://amzn.to/4v3qPFm) | 8MB flash memory, built-in 3D antenna, IR emitter, RGB LED, Button and GROVE interface [^cdc] |
-| M5 Atom S3U        | [ali](https://s.click.aliexpress.com/e/_c3bZmzLz) | USB-A w/ 8MB flash memory, built-in 3D antenna, IR emitter, PDM mic, RGB LED, Button and GROVE interface [^cdc] |
-| M5 Stamp S3        | [ali](https://s.click.aliexpress.com/e/_oB3a0Dv) | Stamp form factor w/ 8MB flash memory, built-in 3D antenna, and RGB LED [^cdc] |
-| Teyleten Robot | [ali](https://s.click.aliexpress.com/e/_c3JEwtzv) [amz/us](https://amzn.to/4jXMRUl) | 8MB flash and 2MB PSRAM dev board, sold as a 3-pack |
+| Chip | Supported | Notes |
+|:-----|:----------|:------|
+| ESP32-S3 | yes &mdash; recommended for new deployments | 8&nbsp;MB flash typical, BT 5.0 LE coded PHY, USB-CDC |
+| ESP32-C3 | yes &mdash; recommended for cost-sensitive deployments | RISC-V, 4&nbsp;MB flash typical |
+| ESP32-C6 | yes | Newer RISC-V part with BT 5.3; firmware build available |
+| Original ESP32 | yes | Still fully supported; stick to branded boards |
+| ESP32-S2 | no | No Bluetooth radio |
+| ESP8266 | no | No Bluetooth radio |
 
-## ESP32
+## Community-tested (branded)
 
-| Name                | Stores         | Notes |
-|:--------------------|:--------------:|-------|
-| M5 Atom (all kinds) | [ali](https://s.click.aliexpress.com/e/_oDWoyd1) [m5stack](https://shop.m5stack.com/collections/m5-controllers/products/atom-lite-esp32-development-kit) [digi](https://www.digikey.com/en/products/detail/m5stack-technology-co-ltd/C008/12088545) | The 3D antenna is much better |
-| M5 Stamp Pico       | [ali](https://s.click.aliexpress.com/e/_olAPbYT) [m5stack](https://shop.m5stack.com/collections/m5-controllers/products/m5stamp-pico-diy-kit) | Small and still has nice 3D antenna |
-| Huzzah32            | [amz/us](https://amzn.to/4kWlmw4) | Much better quality than generic ESP32 dev boards |
+Branded boards we actively point new users at. The [browser installer](/firmware) selects the right firmware flavour automatically. [^cdc]
 
-## Works with caveats
+### ESP32-S3
 
-| Name               | Stores         | Notes |
-|:-------------------|:--------------:|-------|
-| ESP32 dev board clones   | [ali](https://s.click.aliexpress.com/e/_okTMXEr) [amz/us](https://amzn.to/4iWKv86) [amz/uk](https://amzn.to/4iyqHYK) | [^unbranded] No brand |
-| D1 Mini ESP32 (Micro B)  | [amz/us](https://amzn.to/3tlkK8D) | [^unbranded] No brand *Make sure you get the ESP32 NOT the ESP8266* |
-| D1 Mini ESP32 (Type C)   | [ali](https://s.click.aliexpress.com/e/_oC7KI4X) [amz/us](https://amzn.to/41VjFGq) | [^unbranded] No brand |
-| LOLIN D32 ESP32    | [ali](https://s.click.aliexpress.com/e/_onxVPQX) | [^unbranded] No brand |
-| M5Stick-C Plus     | [ali](https://s.click.aliexpress.com/e/_oo2TM0P) [m5stack](https://shop.m5stack.com/collections/m5-controllers/products/m5stickc-plus-esp32-pico-mini-iot-development-kit) [amz/us](https://amzn.to/4iOzTZj) | These are great little devices, but their built-in battery makes them less ideal |
+| Board | Stores | Notes |
+|:------|:-------|:------|
+| M5 Atom S3 Lite | [m5stack](https://docs.m5stack.com/en/core/AtomS3%20Lite) [ali](https://s.click.aliexpress.com/e/_oFSxCND) [amz/us](https://amzn.to/4v3qPFm) | Enclosed, USB-C. 8&nbsp;MB flash, 3D antenna, IR emitter, RGB LED, button, GROVE [^cdc] |
+| M5 Atom S3U | [ali](https://s.click.aliexpress.com/e/_c3bZmzLz) | Enclosed, USB-A. 8&nbsp;MB flash, 3D antenna, IR emitter, PDM mic, RGB LED, button, GROVE [^cdc] |
+| M5 Stamp S3 | [ali](https://s.click.aliexpress.com/e/_oB3a0Dv) | Stamp form. 8&nbsp;MB flash, 3D antenna, RGB LED [^cdc] |
+| Teyleten Robot S3 | [ali](https://s.click.aliexpress.com/e/_c3JEwtzv) [amz/us](https://amzn.to/4jXMRUl) | Dev board. 8&nbsp;MB flash + 2&nbsp;MB PSRAM. Sold as a 3-pack [^cdc] |
 
-## USB C chargers
+### ESP32-C3
 
-* [20W USB C Wall Charger](https://amzn.to/4kXGphK) - Small Fast Charger with Foldable Plug
-* [20W USB C Wall Charger (3 pack)](https://amzn.to/4hFLcBz)
-* [20W USB C Charger](https://s.click.aliexpress.com/e/_c4Myg1Bl) (AliExpress) - PD/QC 3.0 fast charger
+| Board | Stores | Notes |
+|:------|:-------|:------|
+| M5 Stamp C3 Mate | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-mate-with-pin-headers) [ali](https://s.click.aliexpress.com/e/_omweFp9) | Stamp form. 4&nbsp;MB flash, 3D antenna, RGB LED, button |
+| M5 Stamp C3U Mate | [ali](https://s.click.aliexpress.com/e/_onkgbFp) | Stamp form, USB-A. 4&nbsp;MB flash, 3D antenna, RGB LED, button [^cdc] |
+| ESP32-C3-DevKitM-1U | [ali](https://s.click.aliexpress.com/e/_c3bVwFQb) [amz/us](https://amzn.to/41WQXFa) | Espressif's dev board with ESP32-C3-MINI-1U module and U.FL connector. 4&nbsp;MB flash, 160&nbsp;MHz |
 
-## USB C to C cables
+### Original ESP32
 
-* [0.5ft USB C to C](https://amzn.to/4j02B9f)
-* [15cm USB C to C](https://s.click.aliexpress.com/e/_c2vxVV1D) (AliExpress) - right angle, fast charging
+| Board | Stores | Notes |
+|:------|:-------|:------|
+| M5 Atom (Lite / Echo / Matrix) | [ali](https://s.click.aliexpress.com/e/_oDWoyd1) [m5stack](https://shop.m5stack.com/collections/m5-controllers/products/atom-lite-esp32-development-kit) [digi](https://www.digikey.com/en/products/detail/m5stack-technology-co-ltd/C008/12088545) | Enclosed. The 3D antenna is much better than generic clones |
+| M5 Stamp Pico | [ali](https://s.click.aliexpress.com/e/_olAPbYT) [m5stack](https://shop.m5stack.com/collections/m5-controllers/products/m5stamp-pico-diy-kit) | Stamp form. Small, still has a 3D antenna |
+| Adafruit Huzzah32 | [amz/us](https://amzn.to/4kWlmw4) | Dev board. Branded, quality control unlike generic ESP32 dev boards |
 
-## USB A chargers
+## Works, with caveats
 
-* [Dual USB A 3 pack](https://amzn.to/4iA0EAq) - 3-pack of dual-port USB-A chargers with compact cube design
+These boards run ESPresense, but quality and RF behaviour vary. Use one you already own rather than buying a new one. **If a "with caveats" board misbehaves, reproduce on a tier&#8209;1 board before opening a firmware issue** &mdash; RF problems on a marginal clone look identical to firmware bugs and burn a lot of triage time.
 
-## USB A to C cables
+| Board | Caveat | Source |
+|:------|:-------|:-------|
+| AZDelivery ESP32 NodeMCU (WROOM-32 module on a generic dev board) | Works but no brand QC | [#2334][p] / [#1567][1567], [#1577][1577] |
+| Generic D1 Mini ESP32 (Micro-B and USB-C) | Multiple users report working in practice; same no-brand &rarr; no-QC caveat on the RF front-end | [#2334][p] / [#162][162] |
+| LOLIN D32 ESP32 | Works; unbranded RF caveat | [#2334][p] |
+| M5StickC Plus | Built-in battery is a liability for a fixed-in-place node | [#2334][p] |
+| SEEEDSTUDIO XIAO ESP32-C3 | Runs on the `esp32C3` flavour. One report of a board overheating ([#1364][1364]); use a known-good USB-C cable and a real power supply | [#2334][p] / [#1364][1364] |
 
-* [16ft 2 pack](https://amzn.to/3zzTTXW)
-* [1ft 6 pack](https://amzn.to/3kyD8Is)
-* [Straight Adapter 4 Pack](https://amzn.to/4hNrh3O)
-* [Right Angle Adapter 4 Pack](https://amzn.to/4bWWH6o)
+## Steer away
 
-## USB-A to Micro-B cables
+Each of these comes up often enough that it's worth saying plainly:
 
-* [0.5 ft Micro USB Cable](https://amzn.to/4hzksTa)
+- **Unbranded "ESP32 dev board" listings (Amazon / AliExpress).** Cheap and *usually* fine, but WiFi/BLE quality varies wildly and the failure is silent &mdash; the board flashes, joins WiFi, reports to MQTT, but RSSI is erratic and you can't tell whether tracking problems are firmware, calibration or a bad RF front-end. @maxi1134 reports a 40-50% WiFi-retry rate on generic ESP32 dev boards ([#1364][1364], summarised in [#2334][p]). For your first node, spend the extra few dollars on a branded board.
+- **ESP32-CAM.** Not officially supported. Camera owns most of the GPIOs, tighter RAM, no maintained firmware variant. One community member keeps a fork working with source-side modifications ([#1347][1347]); we don't build for it.
+- **ESP32-S2 / ESP8266.** No Bluetooth radio &mdash; physically can't run ESPresense.
+- **NSPanel as a base station.** Open question. The chip is an ESP32, but no one has reported flashing ESPresense over the stock NSPanel firmware and getting both the touch UI and BT scanning working ([#1335][1335]).
+- **GL-S10 Bluetooth IoT Gateway.** Not an ESP32 &mdash; MediaTek MT7621 with a separate BLE module &mdash; so the ESPresense firmware doesn't apply ([#1263][1263]).
+
+## Power and cabling
+
+### USB-C chargers
+
+* [20W USB-C Wall Charger](https://amzn.to/4kXGphK) &mdash; small fast charger with foldable plug
+* [20W USB-C Wall Charger (3 pack)](https://amzn.to/4hFLcBz)
+* [20W USB-C Charger (AliExpress)](https://s.click.aliexpress.com/e/_c4Myg1Bl) &mdash; PD/QC 3.0
+
+### USB-C to C cables
+
+* [0.5 ft USB-C to C](https://amzn.to/4j02B9f)
+* [15 cm USB-C to C, right angle (AliExpress)](https://s.click.aliexpress.com/e/_c2vxVV1D)
+
+### USB-A chargers
+
+* [Dual USB-A 3 pack](https://amzn.to/4iA0EAq) &mdash; compact cube design
+
+### USB-A to C cables
+
+* [16 ft, 2 pack](https://amzn.to/3zzTTXW)
+* [1 ft, 6 pack](https://amzn.to/3kyD8Is)
+* [Straight adapter 4 pack](https://amzn.to/4hNrh3O)
+* [Right-angle adapter 4 pack](https://amzn.to/4bWWH6o)
+
+### USB-A to Micro-B cables
+
+* [0.5 ft Micro USB cable](https://amzn.to/4hzksTa)
+
+## See also
+
+* [Canonical pin #2334][p] &mdash; community discussion, raw quotes, source threads
+* [Install Firmware](/firmware) &mdash; browser-based installer
+* [Discord](https://discord.gg/jbqmn7V6n6) &mdash; faster human turnaround on board questions
 
 ## Footnotes
 
-[^unbranded]: These are cheap, but no brand usually means no quality control, especially on the WiFi/BLE components
-[^cdc]: Use CDC firmware flavor
+[^cdc]: USB-CDC firmware flavour. The [browser installer](/firmware) selects this automatically; pick the `cdc` variant if you're flashing manually.
+
+[p]: https://github.com/ESPresense/ESPresense/discussions/2334
+[162]: https://github.com/ESPresense/ESPresense/discussions/162
+[1263]: https://github.com/ESPresense/ESPresense/discussions/1263
+[1335]: https://github.com/ESPresense/ESPresense/discussions/1335
+[1347]: https://github.com/ESPresense/ESPresense/discussions/1347
+[1364]: https://github.com/ESPresense/ESPresense/discussions/1364
+[1567]: https://github.com/ESPresense/ESPresense/discussions/1567
+[1577]: https://github.com/ESPresense/ESPresense/discussions/1577

--- a/src/content/docs/nodes.md
+++ b/src/content/docs/nodes.md
@@ -20,7 +20,7 @@ Some store links on this page (Amazon, AliExpress) are affiliate links. As an Am
 | Board | Chip | Why it's tier 1 | Stores |
 |:------|:-----|:--------------------|:-------|
 | **M5 Atom S3 Lite** | ESP32-S3 | First-timer pick: ~$15, enclosed, USB-C, status LED, 8 MB flash, noticeably better BT range than original ESP32 [^cdc] | [m5stack](https://docs.m5stack.com/en/core/AtomS3%20Lite) [ali](https://s.click.aliexpress.com/e/_oFSxCND) [amz/us](https://amzn.to/4v3qPFm) |
-| **M5 Stamp C3 Mate** | ESP32-C3 | Cost-conscious pick: stamp form, RISC-V, runs cool, 4 MB flash, 3D antenna, RGB LED | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-mate-with-pin-headers) [ali](https://s.click.aliexpress.com/e/_omweFp9) [amz/us](https://amzn.to/4tVkzP4) |
+| **M5 Stamp C3 Mate** | ESP32-C3 | Cost-conscious pick: stamp form, RISC-V, runs cool, 4 MB flash, 3D antenna, RGB LED | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-5pcs) [ali](https://s.click.aliexpress.com/e/_omweFp9) [amz/us](https://amzn.to/4tVkzP4) |
 
 ## Chip families
 
@@ -52,7 +52,7 @@ Branded boards we actively point new users at. The [browser installer](/firmware
 
 | Board | Stores | Notes |
 |:------|:-------|:------|
-| M5 Stamp C3 Mate | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-mate-with-pin-headers) [ali](https://s.click.aliexpress.com/e/_omweFp9) [amz/us](https://amzn.to/4tVkzP4) | Stamp form. 4 MB flash, 3D antenna, RGB LED, button |
+| M5 Stamp C3 Mate | [m5stack](https://shop.m5stack.com/products/m5stamp-c3-5pcs) [ali](https://s.click.aliexpress.com/e/_omweFp9) [amz/us](https://amzn.to/4tVkzP4) | Stamp form. 4 MB flash, 3D antenna, RGB LED, button |
 | M5 Stamp C3U Mate | [ali](https://s.click.aliexpress.com/e/_onkgbFp) | Stamp form, USB-A. 4 MB flash, 3D antenna, RGB LED, button [^cdc] |
 | ESP32-C3-DevKitM-1U | [ali](https://s.click.aliexpress.com/e/_c3bVwFQb) [amz/us](https://amzn.to/41WQXFa) | Espressif's dev board with ESP32-C3-MINI-1U module and U.FL connector. 4 MB flash, 160 MHz |
 

--- a/src/content/docs/nodes.md
+++ b/src/content/docs/nodes.md
@@ -11,7 +11,7 @@ Community-voiced board data and quotes are lifted from the canonical pin: [discu
 
 ## First-time buyer (tier 1)
 
-If you've never deployed ESPresense before, buy one of these. Both are branded, enclosed (or stamp-form, not a bare clone PCB), ship with a 3D antenna, and are well-supported by the [browser installer](/firmware) — it detects the chip family and lists the matching firmware builds in the dropdown.
+If you've never deployed ESPresense before, buy one of these. Both are branded, enclosed (or stamp-form, not a bare clone PCB), and ship with a 3D antenna. Flash them with the [browser installer](/firmware) and you're done.
 
 :::note[Affiliate disclosure]
 Some store links on this page (Amazon, AliExpress) are affiliate links. As an Amazon Associate, ESPresense earns from qualifying purchases, at no extra cost to you. Affiliate revenue helps fund the project — see [Credits](/credits) for other ways to support.
@@ -37,7 +37,7 @@ Pick a chip first, then a board within it.
 
 ## Community-tested (branded)
 
-Branded boards we actively point new users at. The [browser installer](/firmware) detects the chip family and lists the matching firmware builds in its flavour dropdown. [^cdc]
+Branded boards we actively point new users at. All flash with the [browser installer](/firmware). [^cdc]
 
 ### ESP32-S3
 

--- a/src/content/docs/nodes.md
+++ b/src/content/docs/nodes.md
@@ -11,7 +11,7 @@ Community-voiced board data and quotes are lifted from the canonical pin: [discu
 
 ## First-time buyer (tier 1)
 
-If you've never deployed ESPresense before, buy one of these. Both are branded, enclosed (or stamp-form, not a bare clone PCB), ship with a 3D antenna, and the [browser installer](/firmware) picks the right firmware flavour automatically.
+If you've never deployed ESPresense before, buy one of these. Both are branded, enclosed (or stamp-form, not a bare clone PCB), ship with a 3D antenna, and are well-supported by the [browser installer](/firmware) — it detects the chip family and lists the matching firmware builds in the dropdown.
 
 :::note[Affiliate disclosure]
 Some store links on this page (Amazon, AliExpress) are affiliate links. As an Amazon Associate, ESPresense earns from qualifying purchases, at no extra cost to you. Affiliate revenue helps fund the project — see [Credits](/credits) for other ways to support.
@@ -37,7 +37,7 @@ Pick a chip first, then a board within it.
 
 ## Community-tested (branded)
 
-Branded boards we actively point new users at. The [browser installer](/firmware) selects the right firmware flavour automatically. [^cdc]
+Branded boards we actively point new users at. The [browser installer](/firmware) detects the chip family and lists the matching firmware builds in its flavour dropdown. [^cdc]
 
 ### ESP32-S3
 
@@ -122,7 +122,7 @@ Each of these comes up often enough that it's worth saying plainly:
 
 ## Footnotes
 
-[^cdc]: USB-CDC firmware flavour. The [browser installer](/firmware) selects this automatically; pick the `cdc` variant if you're flashing manually.
+[^cdc]: USB-CDC firmware flavour. Pick the `cdc` variant from the [browser installer](/firmware) flavour dropdown (or when flashing manually).
 
 [p]: https://github.com/ESPresense/ESPresense/discussions/2334
 [162]: https://github.com/ESPresense/ESPresense/discussions/162


### PR DESCRIPTION
Reopens #320 from a local branch so the Cloudflare Pages preview check runs (it doesn't run on fork PRs).

## Summary

Rewrites `src/content/docs/nodes.md` as a Diataxis-mode **reference** page lifted from the canonical pin [ESPresense/ESPresense#2334](https://github.com/ESPresense/ESPresense/discussions/2334):

- **Tier-1 picks at the top** — M5 Atom S3 Lite (first-timer) and M5 Stamp C3 Mate (cost-conscious).
- **Community-tested** boards split by chip family (S3, C3, original ESP32) so readers can pick a chip first and a board within it.
- **Works with caveats** table names the failure modes per board and tells readers to reproduce on a tier-1 board before opening a firmware bug.
- **Steer away** first bullet leads with the RSSI/fleet-calibration argument (and preempts the *"these same cheap boards never drop in ESPHome"* objection — ESPHome isn't doing RSSI distance estimation across a calibrated fleet).
- Affiliate-disclosure aside carried over from main; ESP32-C6 marked supported; M5 Atom S3 Lite rows updated with Amazon + manufacturer-docs links.
- Source-side cleanup: dropped `&mdash;` / `&nbsp;` in favour of literal `—` and spaces (CommonMark/Starlight handle them fine).
- The firmware-version "Last verified" marker is in an HTML comment, not a reader-facing header.

## Test plan
- [x] `npx astro build` — clean, 36 pages.
- [x] Local dev server: `/nodes` renders with all sections, footnote refs resolve, store links open in a new tab (via the rehype plugin merged in #331).
- [x] Reviewer eyeballs desktop and mobile rendering on the Cloudflare Pages preview.

Supersedes #320.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote the Nodes reference page for clarity, added metadata and a "last verified" timestamp
  * New intro pointing to canonical community discussion
  * Added chip-family chooser and tiered "Recommended boards" with bold picks and affiliate disclosure
  * Consolidated caveats into fleet/RSSI guidance and listed specific caveat boards with citations
  * New "Steer away" exclusions and expanded/overhauled footnotes and reference links
  * Reformatted power/cabling sections and added a "See also" list

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ESPresense/ESPresense.com/pull/334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->