### PR TITLE
docs(quick-start): stamp 2-week post-merge friction checkpoint (no friction)

### DIFF
--- a/src/content/docs/quick-start.md
+++ b/src/content/docs/quick-start.md
@@ -171,4 +171,5 @@ Walk back. The sensor flips back to the room name.
 For everything else, the [Troubleshooting section](/troubleshooting/data-flow) and the [GitHub Discussions](https://github.com/ESPresense/ESPresense/discussions) are the places to look. Search before posting — most first-run problems have been answered before.
 
 <!-- Last verified against firmware v4.0.6 on 2026-05-10 with an M5 Atom S3 Lite, a Home Assistant 2026.4 install running the Mosquitto add-on, and an iPhone 15 enrolled via the UI flow. -->
+<!-- Post-merge friction checkpoint 2026-06-05 (ESPA-114): no organic friction reported in the 2-week window after this tutorial shipped (2026-05-22 → 2026-06-05). GitHub Discussions + the CM watch were clean for every section (flashing, discovery, calibration, HA wiring). Still verified against firmware v4.0.6 (current latest release). -->
 


### PR DESCRIPTION
## What

Close-out stamp for the **getting-started tutorial** 2-week post-merge friction checkpoint (Path B of ESPA-114).

The tutorial shipped in #318 on 2026-05-22. The organic-feedback window (2026-05-22 → 2026-06-05) is now closed with **zero friction reported**:

- **GitHub Discussions** (`ESPresense/ESPresense`): no thread opened since the merge (newest by creation is #2334, 2026-05-11); no existing thread references the tutorial as a friction point; no AtomS3 cross-SKU confusion. Latest activity in the whole repo was 2026-05-28.
- **CM organic-friction watch**: clean through 2026-06-05, no Path A friction report filed.
- Docs-repo Discussions are disabled, so the firmware-repo sweep is the complete picture.

## Change

One footer comment added to `quick-start.md` recording the checkpoint result, alongside the original verification line. No reader-visible change. Still verified against firmware **v4.0.6** (current latest release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quick-start documentation with verification checkpoint notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->